### PR TITLE
Add libnvoptix.so symlink

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -397,6 +397,11 @@ main (int argc, char *argv[])
       symlink ("libGLESv2.so." NVIDIA_VERSION, "libGLESv2.so.1");
     }
 
+  if (nvidia_major_version > 396)
+    {
+      symlink ("libnvoptix.so." NVIDIA_VERSION, "libnvoptix.so.1");
+    }
+
   symlink ("libvdpau_nvidia.so." NVIDIA_VERSION, "libvdpau_nvidia.so");
   symlink ("libcuda.so." NVIDIA_VERSION, "libcuda.so.1");
   symlink ("libcuda.so.1", "libcuda.so");


### PR DESCRIPTION
Closes #44 

---

I checked multiple installers and determined that no drivers before the 400 series included the OptiX library.

Specifically for Blender, the [official wiki](https://wiki.blender.org/wiki/Reference/Release_Notes/2.81/Cycles) states `Linux: driver version 435.12 or newer` (even though this driver doesn't appear to have been released publicly; 435.17 is the closet).