### PR TITLE
Include implicit Vulkan layer nvidia_layers.json

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -108,6 +108,11 @@ should_extract (struct archive_entry *entry)
       archive_entry_set_pathname (entry, "./vulkan/icd.d/nvidia_icd.json");
       return 1;
     }
+  if (strcmp (path, "nvidia_layers.json") == 0)
+    {
+      archive_entry_set_pathname (entry, "./vulkan/implicit_layer.d/nvidia_layers.json");
+      return 1;
+    }
   if (strcmp (path, "10_nvidia.json") == 0)
     {
       archive_entry_set_pathname (entry, "./glvnd/egl_vendor.d/10_nvidia.json");


### PR DESCRIPTION
The implicit Vulkan layer "nvidia_layers.json", provided by the Nvidia
drivers, is a requirement for Optimus.

Helps:
https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/35

---

In order to make this implicit layer available in a container, we also need this patch for the freedesktop runtime https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/4723