### PR TITLE
Add libnvidia-fbc.so.1 symlink

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -415,6 +415,7 @@ main (int argc, char *argv[])
   symlink ("libnvidia-opencl.so." NVIDIA_VERSION, "libnvidia-opencl.so");
   symlink ("libnvidia-ml.so." NVIDIA_VERSION, "libnvidia-ml.so.1");
   symlink ("libnvidia-ml.so.1", "libnvidia-ml.so");
+  symlink ("libnvidia-fbc.so." NVIDIA_VERSION, "libnvidia-fbc.so.1");
 
   mkdir ("OpenCL", 0755);
   mkdir ("OpenCL/vendors", 0755);


### PR DESCRIPTION
Closes #68

All versions of the driver support frame buffer capture.