### PR TITLE
Create `lib/gbm/nvidia-drm_gbm.so` symlink

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -417,6 +417,12 @@ main (int argc, char *argv[])
   symlink ("libnvidia-ml.so.1", "libnvidia-ml.so");
   symlink ("libnvidia-fbc.so." NVIDIA_VERSION, "libnvidia-fbc.so.1");
 
+  if (nvidia_major_version >= 495)
+    {
+      mkdir ("gbm", 0755);
+      symlink ("../libnvidia-allocator.so." NVIDIA_VERSION, "gbm/nvidia-drm_gbm.so");
+    }
+
   mkdir ("OpenCL", 0755);
   mkdir ("OpenCL/vendors", 0755);
   create_file_with_content ("OpenCL/vendors/nvidia.icd", "libnvidia-opencl.so");


### PR DESCRIPTION
Partly addresses #76. Complete fix will require some work on freedesktop-sdk side.