### PR TITLE
Create `libnvidia-vulkan-producer.so` symlink

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -429,6 +429,11 @@ main (int argc, char *argv[])
       symlink ("libnvoptix.so." NVIDIA_VERSION, "libnvoptix.so.1");
     }
 
+  if (nvidia_major_version >= 470)
+    {
+      symlink ("libnvidia-vulkan-producer.so." NVIDIA_VERSION, "libnvidia-vulkan-producer.so");
+    }
+
   symlink ("libvdpau_nvidia.so." NVIDIA_VERSION, "libvdpau_nvidia.so");
   symlink ("libcuda.so." NVIDIA_VERSION, "libcuda.so.1");
   symlink ("libcuda.so.1", "libcuda.so");


### PR DESCRIPTION
This soversion-less library appears to be required for Vulkan on Wayland:
```
       135:	file=libnvidia-vulkan-producer.so [0];  dynamically loaded by /usr/lib/x86_64-linux-gnu/GL/nvidia-495-44/lib/libnvidia-glcore.so.495.44 [0]
```

After its addition, `org.freedesktop.Platform.VulkanInfo//21.08` should start to work.

Another piece towards solving #76 