### PR TITLE
Use `ldconfig` to create library symlinks

### DIFF
--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -39,6 +39,13 @@
             ]
         },
         {
+            "name": "ldconfig",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dvm755 -t ${FLATPAK_DEST}/bin/ $(which ldconfig)"
+            ]
+        },
+        {
             "name": "nvidia",
             "make-args": [ "NVIDIA_VERSION=@@NVIDIA_VERSION@@", "NVIDIA_URL=@@NVIDIA_URL@@" ],
             "no-autogen": true,


### PR DESCRIPTION
`ldconfig` is a statically linked program, so we can copy it from the SDK at build time and use at install time without any dependencies.
Letting `ldconfig` create library symlinks for us makes the `apply_extra` significantly simpler and more future-proof: in case of new libraries added, we won't always need to update `apply_extra`.