### PR TITLE
Install application profiles

### DIFF
--- a/nvidia-Makefile
+++ b/nvidia-Makefile
@@ -10,3 +10,5 @@ install:
 	ln -s extra/vulkan ${FLATPAK_DEST}/vulkan
 	ln -s extra/OpenCL ${FLATPAK_DEST}/OpenCL
 	ln -s extra/egl ${FLATPAK_DEST}/egl
+	mkdir -p ${FLATPAK_DEST}/share
+	ln -s ../extra/share/nvidia ${FLATPAK_DEST}/share/nvidia


### PR DESCRIPTION
Profiles are installed to `extra/share/nvidia/`, with a relative symlink targeting this dir at `share/nvidia`.
This will require some relevant changes on the runtime (or app) side to be useful, but we need the profiles to be shipped with GL extension in the first place anyway.
Fixes #66