### PR TITLE
Fix Tesla 520.61.05 hash and size

### DIFF
--- a/data/nvidia-520.61.05-i386.data
+++ b/data/nvidia-520.61.05-i386.data
@@ -1,1 +1,1 @@
-:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:0::https://us.download.nvidia.com/tesla/520.61.05/NVIDIA-Linux-x86_64-520.61.05.run
+:10f6166703aeaffea237fa2d0ccacd0e9357af59b3bbc708a9097c9578509735:404866281::https://us.download.nvidia.com/tesla/520.61.05/NVIDIA-Linux-x86_64-520.61.05.run

--- a/data/nvidia-520.61.05-x86_64.data
+++ b/data/nvidia-520.61.05-x86_64.data
@@ -1,1 +1,1 @@
-:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:0::https://us.download.nvidia.com/tesla/520.61.05/NVIDIA-Linux-x86_64-520.61.05.run
+:10f6166703aeaffea237fa2d0ccacd0e9357af59b3bbc708a9097c9578509735:404866281::https://us.download.nvidia.com/tesla/520.61.05/NVIDIA-Linux-x86_64-520.61.05.run


### PR DESCRIPTION
#134 was missing a size and the hash was incorrect.