### PR TITLE
Add aarch64 Production Drivers

### DIFF
--- a/data/nvidia-470.103.01-aarch64.data
+++ b/data/nvidia-470.103.01-aarch64.data
@@ -1,1 +1,1 @@
-:6f2b401b393e1f6f2239c8c411dd8b6279a324f6db68ef599485f4392dfeaed0:184497677::https://download.nvidia.com/XFree86/Linux-aarch64/470.103.01/NVIDIA-Linux-aarch64-470.103.01.run
+:6f2b401b393e1f6f2239c8c411dd8b6279a324f6db68ef599485f4392dfeaed0:184497677::https://us.download.nvidia.com/XFree86/aarch64/470.103.01/NVIDIA-Linux-aarch64-470.103.01.run

--- a/data/nvidia-470.103.01-aarch64.data
+++ b/data/nvidia-470.103.01-aarch64.data
@@ -1,0 +1,1 @@
+:6f2b401b393e1f6f2239c8c411dd8b6279a324f6db68ef599485f4392dfeaed0:184497677::https://download.nvidia.com/XFree86/Linux-aarch64/470.103.01/NVIDIA-Linux-aarch64-470.103.01.run

--- a/data/nvidia-470.129.06-aarch64.data
+++ b/data/nvidia-470.129.06-aarch64.data
@@ -1,1 +1,1 @@
-:3ff88bd5f1e60fd717c3b2951c9528c8f1c40e2a0dd580eba633974cd5db64ff:183697461::https://download.nvidia.com/XFree86/Linux-aarch64/470.129.06/NVIDIA-Linux-aarch64-470.129.06.run
+:3ff88bd5f1e60fd717c3b2951c9528c8f1c40e2a0dd580eba633974cd5db64ff:183697461::https://us.download.nvidia.com/XFree86/aarch64/470.129.06/NVIDIA-Linux-aarch64-470.129.06.run

--- a/data/nvidia-470.129.06-aarch64.data
+++ b/data/nvidia-470.129.06-aarch64.data
@@ -1,0 +1,1 @@
+:3ff88bd5f1e60fd717c3b2951c9528c8f1c40e2a0dd580eba633974cd5db64ff:183697461::https://download.nvidia.com/XFree86/Linux-aarch64/470.129.06/NVIDIA-Linux-aarch64-470.129.06.run

--- a/data/nvidia-470.141.03-aarch64.data
+++ b/data/nvidia-470.141.03-aarch64.data
@@ -1,1 +1,1 @@
-:3694a82bbebab440979b7aab9b5e3b2e281cb39fac8e56ccdad9e5c8e1142a38:184424192::https://download.nvidia.com/XFree86/Linux-aarch64/470.141.03/NVIDIA-Linux-aarch64-470.141.03.run
+:3694a82bbebab440979b7aab9b5e3b2e281cb39fac8e56ccdad9e5c8e1142a38:184424192::https://us.download.nvidia.com/XFree86/aarch64/470.141.03/NVIDIA-Linux-aarch64-470.141.03.run

--- a/data/nvidia-470.141.03-aarch64.data
+++ b/data/nvidia-470.141.03-aarch64.data
@@ -1,0 +1,1 @@
+:3694a82bbebab440979b7aab9b5e3b2e281cb39fac8e56ccdad9e5c8e1142a38:184424192::https://download.nvidia.com/XFree86/Linux-aarch64/470.141.03/NVIDIA-Linux-aarch64-470.141.03.run

--- a/data/nvidia-470.161.03-aarch64.data
+++ b/data/nvidia-470.161.03-aarch64.data
@@ -1,1 +1,1 @@
-:024fa3dc2910342b1c96fd17db780fd5fc775cf3921324648f22b9f860f1867e:184379305::https://download.nvidia.com/XFree86/Linux-aarch64/470.161.03/NVIDIA-Linux-aarch64-470.161.03.run
+:024fa3dc2910342b1c96fd17db780fd5fc775cf3921324648f22b9f860f1867e:184379305::https://us.download.nvidia.com/XFree86/aarch64/470.161.03/NVIDIA-Linux-aarch64-470.161.03.run

--- a/data/nvidia-470.161.03-aarch64.data
+++ b/data/nvidia-470.161.03-aarch64.data
@@ -1,0 +1,1 @@
+:024fa3dc2910342b1c96fd17db780fd5fc775cf3921324648f22b9f860f1867e:184379305::https://download.nvidia.com/XFree86/Linux-aarch64/470.161.03/NVIDIA-Linux-aarch64-470.161.03.run

--- a/data/nvidia-470.42.01-aarch64.data
+++ b/data/nvidia-470.42.01-aarch64.data
@@ -1,1 +1,1 @@
-:43d34c3762b1584b5993ea1a62cd381b0cf3d59349cb0e9c09334f6aee097148:184108907::https://download.nvidia.com/XFree86/Linux-aarch64/470.42.01/NVIDIA-Linux-aarch64-470.42.01.run
+:43d34c3762b1584b5993ea1a62cd381b0cf3d59349cb0e9c09334f6aee097148:184108907::https://us.download.nvidia.com/XFree86/aarch64/470.42.01/NVIDIA-Linux-aarch64-470.42.01.run

--- a/data/nvidia-470.42.01-aarch64.data
+++ b/data/nvidia-470.42.01-aarch64.data
@@ -1,0 +1,1 @@
+:43d34c3762b1584b5993ea1a62cd381b0cf3d59349cb0e9c09334f6aee097148:184108907::https://download.nvidia.com/XFree86/Linux-aarch64/470.42.01/NVIDIA-Linux-aarch64-470.42.01.run

--- a/data/nvidia-470.57.02-aarch64.data
+++ b/data/nvidia-470.57.02-aarch64.data
@@ -1,1 +1,1 @@
-:4b3e51963b88e8de304a6bca68c64954844ed490156a28483e9272eb79a00451:184167283::https://download.nvidia.com/XFree86/Linux-aarch64/470.57.02/NVIDIA-Linux-aarch64-470.57.02.run
+:4b3e51963b88e8de304a6bca68c64954844ed490156a28483e9272eb79a00451:184167283::https://us.download.nvidia.com/XFree86/aarch64/470.57.02/NVIDIA-Linux-aarch64-470.57.02.run

--- a/data/nvidia-470.57.02-aarch64.data
+++ b/data/nvidia-470.57.02-aarch64.data
@@ -1,0 +1,1 @@
+:4b3e51963b88e8de304a6bca68c64954844ed490156a28483e9272eb79a00451:184167283::https://download.nvidia.com/XFree86/Linux-aarch64/470.57.02/NVIDIA-Linux-aarch64-470.57.02.run

--- a/data/nvidia-470.63.01-aarch64.data
+++ b/data/nvidia-470.63.01-aarch64.data
@@ -1,1 +1,1 @@
-:afd93d8fa44e8e1ac99db647b47ecc1cf9ac1effd93fffd9d61b83c33f7cc315:184137823::https://download.nvidia.com/XFree86/Linux-aarch64/470.63.01/NVIDIA-Linux-aarch64-470.63.01.run
+:afd93d8fa44e8e1ac99db647b47ecc1cf9ac1effd93fffd9d61b83c33f7cc315:184137823::https://us.download.nvidia.com/XFree86/aarch64/470.63.01/NVIDIA-Linux-aarch64-470.63.01.run

--- a/data/nvidia-470.63.01-aarch64.data
+++ b/data/nvidia-470.63.01-aarch64.data
@@ -1,0 +1,1 @@
+:afd93d8fa44e8e1ac99db647b47ecc1cf9ac1effd93fffd9d61b83c33f7cc315:184137823::https://download.nvidia.com/XFree86/Linux-aarch64/470.63.01/NVIDIA-Linux-aarch64-470.63.01.run

--- a/data/nvidia-470.74-aarch64.data
+++ b/data/nvidia-470.74-aarch64.data
@@ -1,1 +1,1 @@
-:d5bb2101574aeb0937f5039ff2297241684a9069e51ee54b0f0839fdef542226:183973692::https://download.nvidia.com/XFree86/Linux-aarch64/470.74/NVIDIA-Linux-aarch64-470.74.run
+:d5bb2101574aeb0937f5039ff2297241684a9069e51ee54b0f0839fdef542226:183973692::https://us.download.nvidia.com/XFree86/aarch64/470.74/NVIDIA-Linux-aarch64-470.74.run

--- a/data/nvidia-470.74-aarch64.data
+++ b/data/nvidia-470.74-aarch64.data
@@ -1,0 +1,1 @@
+:d5bb2101574aeb0937f5039ff2297241684a9069e51ee54b0f0839fdef542226:183973692::https://download.nvidia.com/XFree86/Linux-aarch64/470.74/NVIDIA-Linux-aarch64-470.74.run

--- a/data/nvidia-470.82.00-aarch64.data
+++ b/data/nvidia-470.82.00-aarch64.data
@@ -1,1 +1,1 @@
-:07669bec48c957686075e25c8148f2fb49d0bd436c2b6230330b9dae190d0344:183535007::https://download.nvidia.com/XFree86/Linux-aarch64/470.82.00/NVIDIA-Linux-aarch64-470.82.00.run
+:07669bec48c957686075e25c8148f2fb49d0bd436c2b6230330b9dae190d0344:183535007::https://us.download.nvidia.com/XFree86/aarch64/470.82.00/NVIDIA-Linux-aarch64-470.82.00.run

--- a/data/nvidia-470.82.00-aarch64.data
+++ b/data/nvidia-470.82.00-aarch64.data
@@ -1,0 +1,1 @@
+:07669bec48c957686075e25c8148f2fb49d0bd436c2b6230330b9dae190d0344:183535007::https://download.nvidia.com/XFree86/Linux-aarch64/470.82.00/NVIDIA-Linux-aarch64-470.82.00.run

--- a/data/nvidia-470.86-aarch64.data
+++ b/data/nvidia-470.86-aarch64.data
@@ -1,1 +1,1 @@
-:5b950c276c72da7caff8056b3e5ddf231450d72605337bbc7cc6d3b3713dbb0b:183560501::https://download.nvidia.com/XFree86/Linux-aarch64/470.86/NVIDIA-Linux-aarch64-470.86.run
+:5b950c276c72da7caff8056b3e5ddf231450d72605337bbc7cc6d3b3713dbb0b:183560501::https://us.download.nvidia.com/XFree86/aarch64/470.86/NVIDIA-Linux-aarch64-470.86.run

--- a/data/nvidia-470.86-aarch64.data
+++ b/data/nvidia-470.86-aarch64.data
@@ -1,0 +1,1 @@
+:5b950c276c72da7caff8056b3e5ddf231450d72605337bbc7cc6d3b3713dbb0b:183560501::https://download.nvidia.com/XFree86/Linux-aarch64/470.86/NVIDIA-Linux-aarch64-470.86.run

--- a/data/nvidia-470.94-aarch64.data
+++ b/data/nvidia-470.94-aarch64.data
@@ -1,0 +1,1 @@
+:a1c991051c6cbd3fa69d9768fa7cd0084bfa6d4c384cc6a6e3ab88b5b51e57c8:183639436::https://us.download.nvidia.com/XFree86/aarch64/470.94/NVIDIA-Linux-aarch64-470.94.run

--- a/data/nvidia-495.29.05-aarch64.data
+++ b/data/nvidia-495.29.05-aarch64.data
@@ -1,1 +1,1 @@
-:49fd542c2312468b8aa39d753813fbaaf39ed2db73086f7450ab2cd1e68442e6:210310796::https://download.nvidia.com/XFree86/Linux-aarch64/495.29.05/NVIDIA-Linux-aarch64-495.29.05.run
+:49fd542c2312468b8aa39d753813fbaaf39ed2db73086f7450ab2cd1e68442e6:210310796::https://us.download.nvidia.com/XFree86/aarch64/495.29.05/NVIDIA-Linux-aarch64-495.29.05.run

--- a/data/nvidia-495.29.05-aarch64.data
+++ b/data/nvidia-495.29.05-aarch64.data
@@ -1,0 +1,1 @@
+:49fd542c2312468b8aa39d753813fbaaf39ed2db73086f7450ab2cd1e68442e6:210310796::https://download.nvidia.com/XFree86/Linux-aarch64/495.29.05/NVIDIA-Linux-aarch64-495.29.05.run

--- a/data/nvidia-495.44-aarch64.data
+++ b/data/nvidia-495.44-aarch64.data
@@ -1,1 +1,1 @@
-:dd1eb463972f00a00c2ed05bdba1a496c88e0d446da95450d2a239097afac313:210477242::https://download.nvidia.com/XFree86/Linux-aarch64/495.44/NVIDIA-Linux-aarch64-495.44.run
+:dd1eb463972f00a00c2ed05bdba1a496c88e0d446da95450d2a239097afac313:210477242::https://us.download.nvidia.com/XFree86/aarch64/495.44/NVIDIA-Linux-aarch64-495.44.run

--- a/data/nvidia-495.44-aarch64.data
+++ b/data/nvidia-495.44-aarch64.data
@@ -1,0 +1,1 @@
+:dd1eb463972f00a00c2ed05bdba1a496c88e0d446da95450d2a239097afac313:210477242::https://download.nvidia.com/XFree86/Linux-aarch64/495.44/NVIDIA-Linux-aarch64-495.44.run

--- a/data/nvidia-495.46-aarch64.data
+++ b/data/nvidia-495.46-aarch64.data
@@ -1,0 +1,1 @@
+:4d343e05ad435142aa72ce024a15467da0590465f31de9c6411f069f37b25688:211122869::https://us.download.nvidia.com/XFree86/aarch64/495.46/NVIDIA-Linux-aarch64-495.46.run

--- a/data/nvidia-510.108.03-aarch64.data
+++ b/data/nvidia-510.108.03-aarch64.data
@@ -1,1 +1,1 @@
-:5a3ea7b26da3ce68195d7bdaf4714943639b6ce5467b19d91b717283709f91ee:211471630::https://download.nvidia.com/XFree86/Linux-aarch64/510.108.03/NVIDIA-Linux-aarch64-510.108.03.run
+:5a3ea7b26da3ce68195d7bdaf4714943639b6ce5467b19d91b717283709f91ee:211471630::https://us.download.nvidia.com/XFree86/aarch64/510.108.03/NVIDIA-Linux-aarch64-510.108.03.run

--- a/data/nvidia-510.108.03-aarch64.data
+++ b/data/nvidia-510.108.03-aarch64.data
@@ -1,0 +1,1 @@
+:5a3ea7b26da3ce68195d7bdaf4714943639b6ce5467b19d91b717283709f91ee:211471630::https://download.nvidia.com/XFree86/Linux-aarch64/510.108.03/NVIDIA-Linux-aarch64-510.108.03.run

--- a/data/nvidia-510.39.01-aarch64.data
+++ b/data/nvidia-510.39.01-aarch64.data
@@ -1,0 +1,1 @@
+:7b93dc0571867eaea231613750370c749d81c5e03cbf2949ec6fb9f6a5d40a5e:211307577::https://us.download.nvidia.com/XFree86/aarch64/510.39.01/NVIDIA-Linux-aarch64-510.39.01.run

--- a/data/nvidia-510.47.03-aarch64.data
+++ b/data/nvidia-510.47.03-aarch64.data
@@ -1,1 +1,1 @@
-:ce34d7287b19f13c1ea1d05143500de397fd00aa109d27c5cbfbf06274ffc469:210713072::https://download.nvidia.com/XFree86/Linux-aarch64/510.47.03/NVIDIA-Linux-aarch64-510.47.03.run
+:ce34d7287b19f13c1ea1d05143500de397fd00aa109d27c5cbfbf06274ffc469:210713072::https://us.download.nvidia.com/XFree86/aarch64/510.47.03/NVIDIA-Linux-aarch64-510.47.03.run

--- a/data/nvidia-510.47.03-aarch64.data
+++ b/data/nvidia-510.47.03-aarch64.data
@@ -1,0 +1,1 @@
+:ce34d7287b19f13c1ea1d05143500de397fd00aa109d27c5cbfbf06274ffc469:210713072::https://download.nvidia.com/XFree86/Linux-aarch64/510.47.03/NVIDIA-Linux-aarch64-510.47.03.run

--- a/data/nvidia-510.54-aarch64.data
+++ b/data/nvidia-510.54-aarch64.data
@@ -1,1 +1,1 @@
-:bff7a5640445b3e38b35d9d589b52c7353bb473703b7a5d050aa96aaa35ca896:211311685::https://download.nvidia.com/XFree86/Linux-aarch64/510.54/NVIDIA-Linux-aarch64-510.54.run
+:bff7a5640445b3e38b35d9d589b52c7353bb473703b7a5d050aa96aaa35ca896:211311685::https://us.download.nvidia.com/XFree86/aarch64/510.54/NVIDIA-Linux-aarch64-510.54.run

--- a/data/nvidia-510.54-aarch64.data
+++ b/data/nvidia-510.54-aarch64.data
@@ -1,0 +1,1 @@
+:bff7a5640445b3e38b35d9d589b52c7353bb473703b7a5d050aa96aaa35ca896:211311685::https://download.nvidia.com/XFree86/Linux-aarch64/510.54/NVIDIA-Linux-aarch64-510.54.run

--- a/data/nvidia-510.60.02-aarch64.data
+++ b/data/nvidia-510.60.02-aarch64.data
@@ -1,1 +1,1 @@
-:931521e4fc8175411f2a232e2d3704f8369c21e530283b4fdc4cacb323acc568:211374897::https://download.nvidia.com/XFree86/Linux-aarch64/510.60.02/NVIDIA-Linux-aarch64-510.60.02.run
+:931521e4fc8175411f2a232e2d3704f8369c21e530283b4fdc4cacb323acc568:211374897::https://us.download.nvidia.com/XFree86/aarch64/510.60.02/NVIDIA-Linux-aarch64-510.60.02.run

--- a/data/nvidia-510.60.02-aarch64.data
+++ b/data/nvidia-510.60.02-aarch64.data
@@ -1,0 +1,1 @@
+:931521e4fc8175411f2a232e2d3704f8369c21e530283b4fdc4cacb323acc568:211374897::https://download.nvidia.com/XFree86/Linux-aarch64/510.60.02/NVIDIA-Linux-aarch64-510.60.02.run

--- a/data/nvidia-510.68.02-aarch64.data
+++ b/data/nvidia-510.68.02-aarch64.data
@@ -1,1 +1,1 @@
-:6a4aa4418813dd691b8a1cc7e4f24d82175e7be07c38563dffa1485c6be56562:211263873::https://download.nvidia.com/XFree86/Linux-aarch64/510.68.02/NVIDIA-Linux-aarch64-510.68.02.run
+:6a4aa4418813dd691b8a1cc7e4f24d82175e7be07c38563dffa1485c6be56562:211263873::https://us.download.nvidia.com/XFree86/aarch64/510.68.02/NVIDIA-Linux-aarch64-510.68.02.run

--- a/data/nvidia-510.68.02-aarch64.data
+++ b/data/nvidia-510.68.02-aarch64.data
@@ -1,0 +1,1 @@
+:6a4aa4418813dd691b8a1cc7e4f24d82175e7be07c38563dffa1485c6be56562:211263873::https://download.nvidia.com/XFree86/Linux-aarch64/510.68.02/NVIDIA-Linux-aarch64-510.68.02.run

--- a/data/nvidia-510.73.05-aarch64.data
+++ b/data/nvidia-510.73.05-aarch64.data
@@ -1,1 +1,1 @@
-:02e6026376855c57c40f52e8b5d3c31f1ac30dd62e856ad3de7ec6fb2431a997:211202539::https://download.nvidia.com/XFree86/Linux-aarch64/510.73.05/NVIDIA-Linux-aarch64-510.73.05.run
+:02e6026376855c57c40f52e8b5d3c31f1ac30dd62e856ad3de7ec6fb2431a997:211202539::https://us.download.nvidia.com/XFree86/aarch64/510.73.05/NVIDIA-Linux-aarch64-510.73.05.run

--- a/data/nvidia-510.73.05-aarch64.data
+++ b/data/nvidia-510.73.05-aarch64.data
@@ -1,0 +1,1 @@
+:02e6026376855c57c40f52e8b5d3c31f1ac30dd62e856ad3de7ec6fb2431a997:211202539::https://download.nvidia.com/XFree86/Linux-aarch64/510.73.05/NVIDIA-Linux-aarch64-510.73.05.run

--- a/data/nvidia-510.85.02-aarch64.data
+++ b/data/nvidia-510.85.02-aarch64.data
@@ -1,1 +1,1 @@
-:bb5e844a69bc05dade9148438a71f2bb7dea1864278d37864f1a303e437e40c3:211430737::https://download.nvidia.com/XFree86/Linux-aarch64/510.85.02/NVIDIA-Linux-aarch64-510.85.02.run
+:bb5e844a69bc05dade9148438a71f2bb7dea1864278d37864f1a303e437e40c3:211430737::https://us.download.nvidia.com/XFree86/aarch64/510.85.02/NVIDIA-Linux-aarch64-510.85.02.run

--- a/data/nvidia-510.85.02-aarch64.data
+++ b/data/nvidia-510.85.02-aarch64.data
@@ -1,0 +1,1 @@
+:bb5e844a69bc05dade9148438a71f2bb7dea1864278d37864f1a303e437e40c3:211430737::https://download.nvidia.com/XFree86/Linux-aarch64/510.85.02/NVIDIA-Linux-aarch64-510.85.02.run

--- a/data/nvidia-515.43.04-aarch64.data
+++ b/data/nvidia-515.43.04-aarch64.data
@@ -1,1 +1,1 @@
-:96a3bd2c464191f26763f7c82f34b602aa8fb190bf818943c5e6e19fdf50a671:215715685::https://download.nvidia.com/XFree86/Linux-aarch64/515.43.04/NVIDIA-Linux-aarch64-515.43.04.run
+:96a3bd2c464191f26763f7c82f34b602aa8fb190bf818943c5e6e19fdf50a671:215715685::https://us.download.nvidia.com/XFree86/aarch64/515.43.04/NVIDIA-Linux-aarch64-515.43.04.run

--- a/data/nvidia-515.43.04-aarch64.data
+++ b/data/nvidia-515.43.04-aarch64.data
@@ -1,0 +1,1 @@
+:96a3bd2c464191f26763f7c82f34b602aa8fb190bf818943c5e6e19fdf50a671:215715685::https://download.nvidia.com/XFree86/Linux-aarch64/515.43.04/NVIDIA-Linux-aarch64-515.43.04.run

--- a/data/nvidia-515.48.07-aarch64.data
+++ b/data/nvidia-515.48.07-aarch64.data
@@ -1,1 +1,1 @@
-:a4e071055a5f6c110fd49264d76c57a07f3fbd37b8ee2f9eb90c25f51fa59ef5:217966782::https://download.nvidia.com/XFree86/Linux-aarch64/515.48.07/NVIDIA-Linux-aarch64-515.48.07.run
+:a4e071055a5f6c110fd49264d76c57a07f3fbd37b8ee2f9eb90c25f51fa59ef5:217966782::https://us.download.nvidia.com/XFree86/aarch64/515.48.07/NVIDIA-Linux-aarch64-515.48.07.run

--- a/data/nvidia-515.48.07-aarch64.data
+++ b/data/nvidia-515.48.07-aarch64.data
@@ -1,0 +1,1 @@
+:a4e071055a5f6c110fd49264d76c57a07f3fbd37b8ee2f9eb90c25f51fa59ef5:217966782::https://download.nvidia.com/XFree86/Linux-aarch64/515.48.07/NVIDIA-Linux-aarch64-515.48.07.run

--- a/data/nvidia-515.57-aarch64.data
+++ b/data/nvidia-515.57-aarch64.data
@@ -1,1 +1,1 @@
-:e45e1bd5c6fef6af17caf70b4250b3e1dc2669e1eceec4a21afd4f3aa2899c06:220881279::https://download.nvidia.com/XFree86/Linux-aarch64/515.57/NVIDIA-Linux-aarch64-515.57.run
+:e45e1bd5c6fef6af17caf70b4250b3e1dc2669e1eceec4a21afd4f3aa2899c06:220881279::https://us.download.nvidia.com/XFree86/aarch64/515.57/NVIDIA-Linux-aarch64-515.57.run

--- a/data/nvidia-515.57-aarch64.data
+++ b/data/nvidia-515.57-aarch64.data
@@ -1,0 +1,1 @@
+:e45e1bd5c6fef6af17caf70b4250b3e1dc2669e1eceec4a21afd4f3aa2899c06:220881279::https://download.nvidia.com/XFree86/Linux-aarch64/515.57/NVIDIA-Linux-aarch64-515.57.run

--- a/data/nvidia-515.65.01-aarch64.data
+++ b/data/nvidia-515.65.01-aarch64.data
@@ -1,1 +1,1 @@
-:0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93:220195966::https://download.nvidia.com/XFree86/Linux-aarch64/515.65.01/NVIDIA-Linux-aarch64-515.65.01.run
+:0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93:220195966::https://us.download.nvidia.com/XFree86/aarch64/515.65.01/NVIDIA-Linux-aarch64-515.65.01.run

--- a/data/nvidia-515.65.01-aarch64.data
+++ b/data/nvidia-515.65.01-aarch64.data
@@ -1,0 +1,1 @@
+:0d2ac6c6ca144c8c7bbf1a62034998463b21f2660a793607d88c031650d93e93:220195966::https://download.nvidia.com/XFree86/Linux-aarch64/515.65.01/NVIDIA-Linux-aarch64-515.65.01.run

--- a/data/nvidia-515.76-aarch64.data
+++ b/data/nvidia-515.76-aarch64.data
@@ -1,1 +1,1 @@
-:cbea88605164022ade03d74fb3ed28ef9cb4efe2af3cf904967032f890756cd3:221300159::https://download.nvidia.com/XFree86/Linux-aarch64/515.76/NVIDIA-Linux-aarch64-515.76.run
+:cbea88605164022ade03d74fb3ed28ef9cb4efe2af3cf904967032f890756cd3:221300159::https://us.download.nvidia.com/XFree86/aarch64/515.76/NVIDIA-Linux-aarch64-515.76.run

--- a/data/nvidia-515.76-aarch64.data
+++ b/data/nvidia-515.76-aarch64.data
@@ -1,0 +1,1 @@
+:cbea88605164022ade03d74fb3ed28ef9cb4efe2af3cf904967032f890756cd3:221300159::https://download.nvidia.com/XFree86/Linux-aarch64/515.76/NVIDIA-Linux-aarch64-515.76.run

--- a/data/nvidia-515.86.01-aarch64.data
+++ b/data/nvidia-515.86.01-aarch64.data
@@ -1,1 +1,1 @@
-:642308bd81877f8873ed28d285af71c3b3d3d92174871e765c863a3c1cde846d:221097882::https://download.nvidia.com/XFree86/Linux-aarch64/515.86.01/NVIDIA-Linux-aarch64-515.86.01.run
+:642308bd81877f8873ed28d285af71c3b3d3d92174871e765c863a3c1cde846d:221097882::https://us.download.nvidia.com/XFree86/aarch64/515.86.01/NVIDIA-Linux-aarch64-515.86.01.run

--- a/data/nvidia-515.86.01-aarch64.data
+++ b/data/nvidia-515.86.01-aarch64.data
@@ -1,0 +1,1 @@
+:642308bd81877f8873ed28d285af71c3b3d3d92174871e765c863a3c1cde846d:221097882::https://download.nvidia.com/XFree86/Linux-aarch64/515.86.01/NVIDIA-Linux-aarch64-515.86.01.run

--- a/data/nvidia-520.56.06-aarch64.data
+++ b/data/nvidia-520.56.06-aarch64.data
@@ -1,1 +1,1 @@
-:e3319a184bd1a2813f653691d2c8113e7a79fb25857a3920661d7fa61f6539c3:254864237::https://download.nvidia.com/XFree86/Linux-aarch64/520.56.06/NVIDIA-Linux-aarch64-520.56.06.run
+:e3319a184bd1a2813f653691d2c8113e7a79fb25857a3920661d7fa61f6539c3:254864237::https://us.download.nvidia.com/XFree86/aarch64/520.56.06/NVIDIA-Linux-aarch64-520.56.06.run

--- a/data/nvidia-520.56.06-aarch64.data
+++ b/data/nvidia-520.56.06-aarch64.data
@@ -1,0 +1,1 @@
+:e3319a184bd1a2813f653691d2c8113e7a79fb25857a3920661d7fa61f6539c3:254864237::https://download.nvidia.com/XFree86/Linux-aarch64/520.56.06/NVIDIA-Linux-aarch64-520.56.06.run

--- a/data/nvidia-525.53-aarch64.data
+++ b/data/nvidia-525.53-aarch64.data
@@ -1,1 +1,1 @@
-:d4e576c09c7907448132f60ffb9728df54588aa8253dea1d6fb9bfd16f1a5ba0:262087180::https://download.nvidia.com/XFree86/Linux-aarch64/525.53/NVIDIA-Linux-aarch64-525.53.run
+:d4e576c09c7907448132f60ffb9728df54588aa8253dea1d6fb9bfd16f1a5ba0:262087180::https://us.download.nvidia.com/XFree86/aarch64/525.53/NVIDIA-Linux-aarch64-525.53.run

--- a/data/nvidia-525.53-aarch64.data
+++ b/data/nvidia-525.53-aarch64.data
@@ -1,0 +1,1 @@
+:d4e576c09c7907448132f60ffb9728df54588aa8253dea1d6fb9bfd16f1a5ba0:262087180::https://download.nvidia.com/XFree86/Linux-aarch64/525.53/NVIDIA-Linux-aarch64-525.53.run

--- a/data/nvidia-525.60.11-aarch64.data
+++ b/data/nvidia-525.60.11-aarch64.data
@@ -1,1 +1,1 @@
-:c0b72f1dc82e89e527b9cbd7207db001c70e9aa7abba5cc02b77b7cf245ae43c:261636786::https://download.nvidia.com/XFree86/Linux-aarch64/525.60.11/NVIDIA-Linux-aarch64-525.60.11.run
+:c0b72f1dc82e89e527b9cbd7207db001c70e9aa7abba5cc02b77b7cf245ae43c:261636786::https://us.download.nvidia.com/XFree86/aarch64/525.60.11/NVIDIA-Linux-aarch64-525.60.11.run

--- a/data/nvidia-525.60.11-aarch64.data
+++ b/data/nvidia-525.60.11-aarch64.data
@@ -1,0 +1,1 @@
+:c0b72f1dc82e89e527b9cbd7207db001c70e9aa7abba5cc02b77b7cf245ae43c:261636786::https://download.nvidia.com/XFree86/Linux-aarch64/525.60.11/NVIDIA-Linux-aarch64-525.60.11.run

--- a/data/nvidia-525.78.01-aarch64.data
+++ b/data/nvidia-525.78.01-aarch64.data
@@ -1,1 +1,1 @@
-:32ea502f41eb2ec10fbb2dfce4f856e9d7f167c2f7a711d6b513283506b7b621:262708803::https://download.nvidia.com/XFree86/Linux-aarch64/525.78.01/NVIDIA-Linux-aarch64-525.78.01.run
+:32ea502f41eb2ec10fbb2dfce4f856e9d7f167c2f7a711d6b513283506b7b621:262708803::https://us.download.nvidia.com/XFree86/aarch64/525.78.01/NVIDIA-Linux-aarch64-525.78.01.run

--- a/data/nvidia-525.78.01-aarch64.data
+++ b/data/nvidia-525.78.01-aarch64.data
@@ -1,0 +1,1 @@
+:32ea502f41eb2ec10fbb2dfce4f856e9d7f167c2f7a711d6b513283506b7b621:262708803::https://download.nvidia.com/XFree86/Linux-aarch64/525.78.01/NVIDIA-Linux-aarch64-525.78.01.run

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
     "skip-appstream-check": true,
-    "only-arches": ["x86_64","i386"],
+    "only-arches": ["x86_64","i386","aarch64"],
     "publish-delay-hours": 0
 }

--- a/update-data.sh
+++ b/update-data.sh
@@ -44,18 +44,18 @@ for VER in ${DRIVER_VERSIONS}; do
 
         if [ ${ARCH} == aarch64 ]; then
             if [ ${MAJOR_VER} -lt 470 ]; then
-                break
+                continue
             elif [[ ${TESLA_VERSIONS} == *${VER}* ]]; then
-                break
+                continue
             elif [[ ${VULKAN_VERSIONS} == *${VER}* ]]; then
-                break
+                continue
             else
                 if [ ${VER} == 510.39.01 ]; then
-                    break
+                    continue
                 elif [ ${VER} == 495.46 ]; then
-                    break
+                    continue
                 elif [ ${VER} == 470.94 ]; then
-                    break
+                    continue
                 fi
             fi
         fi

--- a/update-data.sh
+++ b/update-data.sh
@@ -49,14 +49,6 @@ for VER in ${DRIVER_VERSIONS}; do
                 continue
             elif [[ ${VULKAN_VERSIONS} == *${VER}* ]]; then
                 continue
-            else
-                if [ ${VER} == 510.39.01 ]; then
-                    continue
-                elif [ ${VER} == 495.46 ]; then
-                    continue
-                elif [ ${VER} == 470.94 ]; then
-                    continue
-                fi
             fi
         fi
 
@@ -87,10 +79,13 @@ for VER in ${DRIVER_VERSIONS}; do
         else
             URL=https://us.download.nvidia.com/XFree86/Linux-${NVIDIA_ARCH}/${VER}/NVIDIA-Linux-${NVIDIA_ARCH}-${VER}${SUFFIX}.run
             if ! curl -f -o dl ${URL}; then
-                URL=https://download.nvidia.com/XFree86/Linux-${NVIDIA_ARCH}/${VER}/NVIDIA-Linux-${NVIDIA_ARCH}-${VER}${SUFFIX}.run
+                URL=https://us.download.nvidia.com/XFree86/${NVIDIA_ARCH}/${VER}/NVIDIA-Linux-${NVIDIA_ARCH}-${VER}${SUFFIX}.run
                 if ! curl -f -o dl ${URL}; then
-                    echo "Unable to find URL for version ${VER}, arch ${ARCH}"
-                    exit 1
+                    URL=https://download.nvidia.com/XFree86/Linux-${NVIDIA_ARCH}/${VER}/NVIDIA-Linux-${NVIDIA_ARCH}-${VER}${SUFFIX}.run
+                    if ! curl -f -o dl ${URL}; then
+                        echo "Unable to find URL for version ${VER}, arch ${ARCH}"
+                        exit 1
+                    fi
                 fi
             fi
         fi

--- a/update-data.sh
+++ b/update-data.sh
@@ -5,7 +5,7 @@ source ./versions.sh
 set -e
 
 for VER in ${DRIVER_VERSIONS}; do
-    for ARCH in x86_64 i386; do
+    for ARCH in x86_64 i386 aarch64; do
         F="data/nvidia-${VER}-${ARCH}.data"
         if [ -f ${F} ]; then continue; fi
 
@@ -28,6 +28,9 @@ for VER in ${DRIVER_VERSIONS}; do
             else
                 SUFFIX=
             fi
+        elif [ ${ARCH} == aarch64 ]; then
+            NVIDIA_ARCH=aarch64
+            SUFFIX=
         else
             NVIDIA_ARCH=x86
             SUFFIX=
@@ -37,6 +40,24 @@ for VER in ${DRIVER_VERSIONS}; do
         # 32bit compat libs
         if [ ${ARCH} == i386 ] && [ ${MAJOR_VER} -gt 390 ]; then
             NVIDIA_ARCH=x86_64
+        fi
+
+        if [ ${ARCH} == aarch64 ]; then
+            if [ ${MAJOR_VER} -lt 470 ]; then
+                break
+            elif [[ ${TESLA_VERSIONS} == *${VER}* ]]; then
+                break
+            elif [[ ${VULKAN_VERSIONS} == *${VER}* ]]; then
+                break
+            else
+                if [ ${VER} == 510.39.01 ]; then
+                    break
+                elif [ ${VER} == 495.46 ]; then
+                    break
+                elif [ ${VER} == 470.94 ]; then
+                    break
+                fi
+            fi
         fi
 
         echo "Generating ${F}"


### PR DESCRIPTION
Modify update script to add only the aarch64 Production Drivers from versions 470 and up.
Adding data files
Enable building for aarch64

Fixes #116 