### PR TITLE
Support extracting zstd-compressed drivers

### DIFF
--- a/nvidia-Makefile
+++ b/nvidia-Makefile
@@ -1,5 +1,5 @@
 all:
-	gcc -o apply_extra -Wall -static -DNVIDIA_VERSION='"'$(subst -,.,${NVIDIA_VERSION})'"' -DNVIDIA_BASENAME='"'$(notdir ${NVIDIA_URL})'"' nvidia-apply-extra.c $(CFLAGS) ${LDFLAGS} -larchive -lz -llzma
+	gcc -o apply_extra -Wall -static -DNVIDIA_VERSION='"'$(subst -,.,${NVIDIA_VERSION})'"' -DNVIDIA_BASENAME='"'$(notdir ${NVIDIA_URL})'"' nvidia-apply-extra.c $(CFLAGS) ${LDFLAGS} -larchive -lz -llzma -lzstd
 
 install:
 	mkdir -p ${FLATPAK_DEST}/bin

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -202,6 +202,7 @@ extract (int fd)
   archive_read_support_format_tar (a);
   archive_read_support_filter_xz (a);
   archive_read_support_filter_gzip (a);
+  archive_read_support_filter_zstd (a);
 
   if ((r = archive_read_open_fd (a, fd, 16*1024)))
     die_with_libarchive (a, "archive_read_open_fd: %s");

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -33,8 +33,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.libarchive.org/downloads/libarchive-3.2.2.tar.gz",
-                    "sha256": "691c194ee132d1f0f7a42541f091db811bc2e56f7107e9121be2bc8c04f1060f"
+                    "url": "https://www.libarchive.de/downloads/libarchive-3.6.2.tar.xz",
+                    "sha256": "9e2c1b80d5fbe59b61308fdfab6c79b5021d7ff4ff2489fb12daf0a96a83551d"
                 }
             ]
         },

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -7,8 +7,9 @@
     "runtime-version": "@@SDK_RUNTIME_VERSION@@",
     "sdk-extensions": [],
     "separate-locales": false,
-    "cleanup": [ ],
+    "cleanup": ["/include"],
     "build-options" : {
+        "append-ld-library-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib",
         "cflags": "-O2 -g -I/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/include",
         "cxxflags": "-O2 -g",
         "prefix": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@",
@@ -22,6 +23,25 @@
         "--metadata=Extra Data=NoRuntime"
     ],
     "modules": [
+        {
+            "name": "libzstd",
+            "no-autogen": true,
+            "subdir": "lib",
+            "make-args": [
+                "lib-mt"
+            ],
+            "make-install-args": [
+                "PREFIX=${FLATPAK_DEST}",
+                "LIBDIR=${FLATPAK_DEST}/lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/facebook/zstd/releases/download/v1.5.4/zstd-1.5.4.tar.gz",
+                    "sha256": "0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424"
+                }
+            ]
+        },
         {
             "cleanup": ["/include", "/share"],
             "name": "libarchive",


### PR DESCRIPTION
Starting from beta release 530.30.02, NVIDIA began compressing their drivers using zstd instead of xz.

From the [release notes](https://www.nvidia.com/Download/driverResults.aspx/199985/en-us/):

>Changed the compression format of the .run installer package from xz to zstd. This results in a smaller compressed package, and faster decompression performance. A fallback zstd decompressor is embedded into the installer package for systems which do not already have a zstd decompression program installed.

Fixes #160