### PR TITLE
Fix CUDA 545.23.08 drivers

### DIFF
--- a/data/nvidia-545.23.08-aarch64.data
+++ b/data/nvidia-545.23.08-aarch64.data
@@ -1,1 +1,1 @@
-:bce6bb8b293c33c3ed0c1b65120c70587cc29e1b94ea8679ebb14c32b3858b5e:3543476599::https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux_sbsa.run
+:e5509be6a999f9893577dda8a49dedbd7094b64ec443d29d577f8fae48fbece8:255861301::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-aarch64-545.23.08.run

--- a/data/nvidia-545.23.08-i386.data
+++ b/data/nvidia-545.23.08-i386.data
@@ -1,1 +1,1 @@
-:b73d18ccd5ff85bbae32b425dfb82729612ede65b07a37cd5e2b574190614038:4368526618::https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux.run
+:5d2bc78af8a31731c6072a334dda5825e1188bd5a7bc7cc3e77875924624a014:324831132::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-545.23.08.run

--- a/data/nvidia-545.23.08-x86_64.data
+++ b/data/nvidia-545.23.08-x86_64.data
@@ -1,1 +1,1 @@
-:b73d18ccd5ff85bbae32b425dfb82729612ede65b07a37cd5e2b574190614038:4368526618::https://developer.download.nvidia.com/compute/cuda/12.3.1/local_installers/cuda_12.3.1_545.23.08_linux.run
+:5d2bc78af8a31731c6072a334dda5825e1188bd5a7bc7cc3e77875924624a014:324831132::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-545.23.08.run


### PR DESCRIPTION
It looks like something is broken with PR #214, which should have automatically downloaded the CUDA `.run` file, then extracted it to find the actual NVIDIA driver `.run` file to install, but instead it results in #224.

I'm not exactly sure what the issue is, but if we self-host the NVIDIA driver `.run` file, the old existing process should work just as well!

These files are hosted at https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/tag/cuda, which seems okay under both NVIDIA's and GitHub's rules (see https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/224#issuecomment-1893017543).

This will only be required until we switch to using a normal package, and not extra-data (see https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/pull/167).

This should hopefully fix #224, and actually fix #213!

### Testing methodology

I've tested this locally on an `x86_64` machine by editing `build.sh` to only have the `545.23.08` driver version:

```diff
diff --git a/build.sh b/build.sh
index 65180ab..8411bb6 100755
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ set -x
 SDK_BRANCH=1.4
 SDK_RUNTIME_VERSION=1.6
 
-for VER in $DRIVER_VERSIONS; do
+for VER in '545.23.08'; do
     F="data/nvidia-$VER-$ARCH.data"
     if [ ! -f $F ]; then
         echo WARNING, no data file for $VER $ARCH
```

Then I ran `./build.sh x86_64 repo "" '--install --user' 'Fix CUDA 545.23.08 drivers (6157761)'` and it worked.