### PR TITLE
Makefile: Set default options for `flatpak-builder`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Override the arch with `make ARCH=i386`
-ARCH   ?= $(shell flatpak --default-arch)
-REPO   ?= repo
+ARCH    ?= $(shell flatpak --default-arch)
+REPO    ?= repo
+FB_ARGS ?= --user --install-deps-from=flathub
 
 all: ${REPO}
-	./build.sh "${ARCH}" "${REPO}" "${EXPORT_ARGS}"
+	./build.sh "${ARCH}" "${REPO}" "${EXPORT_ARGS}" "${FB_ARGS}" "${SUBJECT}"
 
 
 ${REPO}:


### PR DESCRIPTION
To improve a bit the experience when packaging locally.

These are the default arguments currently used by Flathub's buildbot.