### PR TITLE
Only install application profiles on 319xx and newer

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -485,10 +485,13 @@ main (int argc, char *argv[])
       symlink ("../libnvidia-allocator.so." NVIDIA_VERSION, "gbm/nvidia-drm_gbm.so");
     }
 
-  symlink ("nvidia-application-profiles-" NVIDIA_VERSION "-key-documentation",
-           "share/nvidia/nvidia-application-profiles-key-documentation");
-  symlink ("nvidia-application-profiles-" NVIDIA_VERSION "-rc",
-           "share/nvidia/nvidia-application-profiles-rc");
+  if (nvidia_major_version >= 319)
+    {
+      symlink ("nvidia-application-profiles-" NVIDIA_VERSION "-key-documentation",
+               "share/nvidia/nvidia-application-profiles-key-documentation");
+      symlink ("nvidia-application-profiles-" NVIDIA_VERSION "-rc",
+               "share/nvidia/nvidia-application-profiles-rc");
+    }
 
   mkdir ("OpenCL", 0755);
   mkdir ("OpenCL/vendors", 0755);


### PR DESCRIPTION
From the release notes of [beta driver 319.12](https://www.nvidia.com/Download/driverResults.aspx/60198/en-us/):

>Added support for application profiles to the NVIDIA client-side GLX implementation. See the "Application Profiles" chapter of the README for more information.