### PR TITLE
Fix symlinking rules for `libnvidia-vulkan-producer.so`

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -11,7 +11,9 @@
 #include <errno.h>
 #include <linux/limits.h>
 
-int nvidia_major_version;
+int nvidia_major_version = 0;
+int nvidia_minor_version = 0;
+int nvidia_patch_version = 0;
 
 void
 die_with_error (const char *format, ...)
@@ -49,6 +51,15 @@ die (const char *format, ...)
   fprintf (stderr, "\n");
 
   exit (1);
+}
+
+int
+parse_driver_version (const char *version,
+                      int *major,
+                      int *minor,
+                      int *patch)
+{
+  return sscanf(version, "%d.%d.%d", major, minor, patch) < 2;
 }
 
 static int
@@ -436,7 +447,11 @@ main (int argc, char *argv[])
   int skip_lines;
   off_t tar_start;
 
-  nvidia_major_version = atoi (NVIDIA_VERSION);
+  if (parse_driver_version (NVIDIA_VERSION,
+                            &nvidia_major_version,
+                            &nvidia_minor_version,
+                            &nvidia_patch_version))
+    die ("failed to parse driver version '%s'.", NVIDIA_VERSION);
 
   fd = open (NVIDIA_BASENAME, O_RDONLY);
   if (fd == -1)

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -479,9 +479,12 @@ main (int argc, char *argv[])
   if (subprocess (ldconfig_argv))
     die ("running ldconfig failed");
 
-  if (nvidia_major_version >= 470 && nvidia_major_version < 550)
+  if (((nvidia_major_version == 470 && nvidia_minor_version >= 63) ||
+      nvidia_major_version >= 495) && nvidia_major_version < 545 &&
+      strcmp(ARCH, "i386") != 0)
     {
-      symlink ("libnvidia-vulkan-producer.so." NVIDIA_VERSION, "libnvidia-vulkan-producer.so");
+      symlink ("libnvidia-vulkan-producer.so." NVIDIA_VERSION,
+               "libnvidia-vulkan-producer.so");
     }
 
   if (nvidia_major_version >= 550)


### PR DESCRIPTION
New rules for symlinking this library:

- Library is only present on versions 470xx through 535xx.
  There are two exceptions to this, however:
  Versions [470.42.01](https://www.nvidia.com/Download/driverResults.aspx/176525/en-us/) and [470.57.02](https://www.nvidia.com/Download/driverResults.aspx/177145/en-us/) don't include it, for some reason.

- There's no 32-bit counterpart for this library.