### PR TITLE
Go back to Autotools for building libarchive

### DIFF
--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -10,6 +10,7 @@
     "cleanup": ["/include"],
     "build-options" : {
         "append-ld-library-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib",
+        "append-pkg-config-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib/pkgconfig",
         "cflags": "-O2 -g -I/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/include",
         "cxxflags": "-O2 -g",
         "prefix": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@",
@@ -48,7 +49,7 @@
             "config-opts": [ "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
                              "--without-bz2lib", "--without-iconv", "--without-lz4", "--without-lzo2", "--without-nettle",
                              "--without-openssl", "--without-xml2", "--without-expat", "--disable-bsdcat", "--disable-bsdcpio",
-                             "--disable-bsdtar"
+                             "--disable-bsdtar", "--disable-bsdunzip", "--without-libb2", "--without-cng", "--without-mbedtls"
                            ],
             "sources": [
                 {

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -10,7 +10,6 @@
     "cleanup": ["/include"],
     "build-options" : {
         "append-ld-library-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib",
-        "append-pkg-config-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib/pkgconfig",
         "cflags": "-O2 -g -I/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/include",
         "cxxflags": "-O2 -g",
         "prefix": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@",
@@ -44,27 +43,13 @@
             ]
         },
         {
-            "cleanup": ["*"],
+            "cleanup": ["/include", "/share"],
             "name": "libarchive",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [
-                "-DBUILD_SHARED_LIBS=OFF",
-                "-DENABLE_OPENSSL=OFF",
-                "-DENABLE_LIBB2=OFF",
-                "-DENABLE_LZ4=OFF",
-                "-DENABLE_BZip2=OFF",
-                "-DENABLE_LIBXML2=OFF",
-                "-DENABLE_EXPAT=OFF",
-                "-DENABLE_CNG=OFF",
-                "-DENABLE_TAR=OFF",
-                "-DENABLE_CPIO=OFF",
-                "-DENABLE_CAT=OFF",
-                "-DENABLE_UNZIP=OFF",
-                "-DENABLE_XATTR=OFF",
-                "-DENABLE_ACL=OFF",
-                "-DENABLE_ICONV=OFF",
-                "-DENABLE_TEST=OFF"
-            ],
+            "config-opts": [ "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
+                             "--without-bz2lib", "--without-iconv", "--without-lz4", "--without-lzo2", "--without-nettle",
+                             "--without-openssl", "--without-xml2", "--without-expat", "--disable-bsdcat", "--disable-bsdcpio",
+                             "--disable-bsdtar"
+                           ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
This reverts commit https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/commit/b1d0cafed1172544fa7ff4049a0ff12657a3de00.

After moving to CMake, libarchive began failing to build on i386. See https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/283#issuecomment-2307481607 for more details on the error.

I also took this opportunity to add new build flags that disable unused components of libarchive, which should slightly speed up the build process:

- `--disable-bsdunzip`: Disable build of bsdunzip
- `--without-libb2`: Don't build support for BLAKE2 through libb2
- `--without-cng`: Don't build support of CNG(Crypto Next Generation)
- `--without-mbedtls`: Build without crypto support from mbed TLS

Closes #283