### PR TITLE
libzstd: Don't clean up files

### DIFF
--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -28,7 +28,6 @@
             "name": "libzstd",
             "buildsystem": "simple",
             "subdir": "lib",
-            "cleanup": ["*"],
             "build-options": {
                 "cppflags": "-DZSTD_MULTITHREAD"
             },


### PR DESCRIPTION
The cleaning up is already [covered by](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/blob/4b830af0570b68f9a744d20ebd67eb437df0a658/nvidia-Makefile#L7) `nvidia-Makefile`.

This change stops `flatpak-builder` from inadvertently removing the `lib` -> `extra` symlink at the "clean up stage", which was preventing apps from locating driver libraries.

Fixes #288