### PR TITLE
Update dependencies used by the driver extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd org.freedesktop.Platform.GL.nvidia
 echo 'DRIVER_VERSIONS="560.35.03"' >> versions.sh
 ```
 
-5\. Install the appropriate 1.6 Freedesktop Platform/SDK for your CPU architecture:
+**5\.** Install the appropriate 1.6 Freedesktop Platform/SDK for your CPU architecture:
 
 ```bash
 flatpak --user install --no-related flathub "org.freedesktop.Platform/$(flatpak --default-arch)/1.6"

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -45,7 +45,7 @@
         {
             "cleanup": ["/include", "/share"],
             "name": "libarchive",
-            "config-opts": [ "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
+            "config-opts": [ "--disable-dependency-tracking", "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
                              "--without-bz2lib", "--without-iconv", "--without-lz4", "--without-lzo2", "--without-nettle",
                              "--without-openssl", "--without-xml2", "--without-expat", "--disable-bsdcat", "--disable-bsdcpio",
                              "--disable-bsdtar", "--disable-bsdunzip", "--without-libb2", "--without-cng", "--without-mbedtls"

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/facebook/zstd/releases/download/v1.5.4/zstd-1.5.4.tar.gz",
-                    "sha256": "0f470992aedad543126d06efab344dc5f3e171893810455787d38347343a4424"
+                    "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz",
+                    "sha256": "8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1"
                 }
             ]
         },

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -53,8 +53,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.libarchive.de/downloads/libarchive-3.7.4.tar.xz",
-                    "sha256": "f887755c434a736a609cbd28d87ddbfbe9d6a3bb5b703c22c02f6af80a802735"
+                    "url": "https://github.com/libarchive/libarchive/releases/download/v3.7.5/libarchive-3.7.5.tar.xz",
+                    "sha256": "ca74ff8f99dd40ab8a8274424d10a12a7ec3f4428dd35aee9fdda8bdb861b570"
                 }
             ]
         },


### PR DESCRIPTION
Changes:

- `libarchive`: update to [3.7.5](https://github.com/libarchive/libarchive/releases/tag/v3.7.5)
- `libzstd`: update to [1.5.6](https://github.com/facebook/zstd/releases/tag/v1.5.6)

There’s also a change where `libarchive` is configured with `--disable-dependency-tracking`, which, on my old 2013 quad-core machine, yields a decrease of ~4.6 seconds in overall build time.

These changes were tested locally, by building and installing the 560.35.03 driver for `x86_64` and `i386`.