### PR TITLE
Add CUDA 560.35.05

### DIFF
--- a/data/nvidia-560.35.05-aarch64.data
+++ b/data/nvidia-560.35.05-aarch64.data
@@ -1,0 +1,1 @@
+:9ac1d3242e7bb5254899d7c4f13ab01cfed38ca34f7507006259d6e6cdda54e0:248783781::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-aarch64-560.35.05.run

--- a/data/nvidia-560.35.05-i386.data
+++ b/data/nvidia-560.35.05-i386.data
@@ -1,0 +1,1 @@
+:267ab3a9c5e5b47e648de33991e688938d08d98983caccb770c5c643340d091d:322572600::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-560.35.05.run

--- a/data/nvidia-560.35.05-x86_64.data
+++ b/data/nvidia-560.35.05-x86_64.data
@@ -1,0 +1,1 @@
+:267ab3a9c5e5b47e648de33991e688938d08d98983caccb770c5c643340d091d:322572600::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-560.35.05.run

--- a/versions.sh
+++ b/versions.sh
@@ -14,7 +14,7 @@ TESLA_VERSIONS="550.90.12 550.54.15 535.216.01 535.183.06 535.183.01 535.161.08 
 # NVIDIA sometimes publishes separate drivers just for CUDA that aren't available anywhere else
 # You need to manually create an entry in `data/` for this version, since these drivers exist
 # only at https://developer.nvidia.com/cuda-toolkit-archive for a specific CUDA version
-CUDA_VERSIONS="555.42.06 545.23.08"
+CUDA_VERSIONS="560.35.05 555.42.06 545.23.08"
 
 # TODO: When do we drop these?
 # Probably never: https://ahayzen.com/direct/flathub_downloads_only_nvidia_runtimes.txt


### PR DESCRIPTION
As you folks might already know, some driver versions are not released by NVIDIA in the usual manner.

This version can only be found in the 4 GB installer of CUDA 12.6 Update 3, and so I've manually extracted the embedded `.run` installers from them, and uploaded them to our [Releases page](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/tag/cuda).