### PR TITLE
Install unversioned `libnvidia-api.so.1` library

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -201,7 +201,8 @@ should_extract (struct archive_entry *entry)
   if (strstr (path, "egl-wayland") ||
       strstr (path, "egl-gbm") ||
       strstr (path, "egl-xcb") ||
-      strstr (path, "egl-xlib"))
+      strstr (path, "egl-xlib") ||
+      strstr (path, "libnvidia-api"))
     {
       if (is_compat32)
         archive_entry_set_pathname (entry, path);


### PR DESCRIPTION
This library was introduced with the 525xx series:

>The NVAPI library (`/usr/lib/libnvidia-api.so.1;`); NVAPI provides an interface for managing properties of GPUs. The NVAPI library provides runtime support for NVAPI applications.

Source: https://download.nvidia.com/XFree86/Linux-x86_64/525.53/README/installedcomponents.html

Fixes #318