### PR TITLE
Package the i386 driver on x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The script will download the drivers from the nvidia servers and place the
 **1\.** Install the following packages:
 
 ```bash
-flatpak-builder git make
+flatpak git
 ```
 
 **2\.** Add the Flathub repository:
@@ -20,14 +20,20 @@ flatpak-builder git make
 flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 ```
 
-**3\.** Clone this repository:
+**3\.** Install `org.flatpak.Builder`:
+
+```bash
+flatpak --user install flathub org.flatpak.Builder
+```
+
+**4\.** Clone this repository:
 
 ```bash
 git clone https://github.com/flathub/org.freedesktop.Platform.GL.nvidia.git
 cd org.freedesktop.Platform.GL.nvidia
 ```
 
-**4\.** Assuming you already know what driver version you want to build, use the following command to modify `versions.sh`:
+**5\.** Assuming you already know what driver version you want to build, use the following command to modify `versions.sh`:
 
 ```bash
 # In this example, only the 560.35.03 driver will be built.
@@ -35,32 +41,16 @@ cd org.freedesktop.Platform.GL.nvidia
 echo 'DRIVER_VERSIONS="560.35.03"' >> versions.sh
 ```
 
-**5\.** Install the appropriate 1.6 Freedesktop Platform/SDK for your CPU architecture:
+**6\.** Run the `update-data.sh` script to ensure the required metadata files about the driver are present:
 
 ```bash
-flatpak --user install --no-related flathub "org.freedesktop.Platform/$(flatpak --default-arch)/1.6"
-flatpak --user install --no-related flathub "org.freedesktop.Sdk/$(flatpak --default-arch)/1.6"
+./update-data.sh
 ```
 
-**6\.** This step is not mandatory, but highly recommended for `x86_64` users (`aarch64` users should skip this):
-
-It's about building the `i386` driver, which is necessary for 32-bit 3D apps and games to work.
-
-If you want to proceed, [these steps](https://github.com/guihkx/freedesktop-sdk-1.6-i386/releases/latest) will guide you on how to download and set up a third-party build (because it's not available on Flathub anymore) of the i386 1.6 Freedesktop SDK.
-
-Once you finish doing that, you can continue following the steps below.
-
-**7\.** Invoke the build command to build for your CPU architecture:
+**7\.** Invoke the build command to build for your CPU architecture (Note: if you're on `x86_64`, the 32-bit driver also gets built):
 
 ```bash
-make FB_ARGS='--user'
-```
-
-**7. a)** *(Optional)* If you have set up the i386 1.6 SDK as suggested in the previous step, you also need to run these two commands to create a i386 build:
-
-```bash
-make ARCH=i386 FB_ARGS='--user'
-flatpak build-update-repo --no-summary-index repo/
+flatpak run --command=make --env=FLATPAK_USER_DIR=$HOME/.local/share/flatpak org.flatpak.Builder
 ```
 
 **8\.** Create a local Flatpak remote named `nvidia-local`, pointing to the `repo/` directory:
@@ -79,8 +69,7 @@ flatpak --user remote-ls nvidia-local
 
 ```bash
 flatpak --user install nvidia-local org.freedesktop.Platform.GL.nvidia-560-35-03
-# And if you built the i386 driver...
-flatpak --user install nvidia-local org.freedesktop.Platform.GL32.nvidia-560-35-03
+flatpak --user install nvidia-local org.freedesktop.Platform.GL32.nvidia-560-35-03 # 32-bit driver (if you built on x86_64)
 ```
 
 **11\.** *(Optional)* If you want to free disk space, you can then disable the `nvidia-local` repository and delete the `repo` directory (this is safe, and will not uninstall your drivers):

--- a/build.sh
+++ b/build.sh
@@ -1,45 +1,79 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
 source ./versions.sh
 
 ARCH=$1
 REPO=$2
 EXPORT_ARGS=$3
 FB_ARGS=$4
-SUBJECT=${5:-"org.freedesktop.Platform.GL.nvidia `git rev-parse HEAD`"}
+SUBJECT=$5
 
 set -e
 set -x
 
+EXT_PREFIX='org.freedesktop.Platform.GL.nvidia'
 SDK_BRANCH=1.4
-SDK_RUNTIME_VERSION=1.6
+SDK_RUNTIME_VERSION=24.08
 
 for VER in $DRIVER_VERSIONS; do
-    F="data/nvidia-$VER-$ARCH.data"
-    if [ ! -f $F ]; then
-        echo WARNING, no data file for $VER $ARCH
-        continue
+  if test "${ARCH}" = 'x86_64'; then
+    # If we're building the x86_64 driver, we also build the i386 driver.
+    # Note: The i386 driver has to be built first, otherwise the x86_64 ostree repo gets overwritten by it.
+    TARGET_ARCHES="i386 x86_64"
+  else
+    TARGET_ARCHES=${ARCH}
+  fi
+
+  for TARGET_ARCH in ${TARGET_ARCHES}; do
+    DATA_FILE="data/nvidia-${VER}-${TARGET_ARCH}.data"
+    if [ ! -f "${DATA_FILE}" ]; then
+      echo "WARNING: No data file for ${VER} ${TARGET_ARCH}"
+      continue
     fi
-    NVIDIA_VERSION=$(echo $VER | sed "s/\./-/;s/\./-/")
-    EXTRA_DATA=$(cat $F)
-    NVIDIA_URL=$(cat $F | sed "s/:[^:]*:[^:]*:[^:]*://")
-    rm -f org.freedesktop.Platform.GL.nvidia-$NVIDIA_VERSION.json
-    sed -e "s/@@SDK_BRANCH@@/${SDK_BRANCH}/g"			\
-        -e "s/@@SDK_RUNTIME_VERSION@@/${SDK_RUNTIME_VERSION}/g"	\
-        -e "s/@@NVIDIA_VERSION@@/${NVIDIA_VERSION}/g"		\
-        -e "s=@@EXTRA_DATA@@=${EXTRA_DATA}=g" \
-        -e "s=@@NVIDIA_URL@@=${NVIDIA_URL}=g" \
-        -e "s=@@ARCH@@=${ARCH}=g" \
-        org.freedesktop.Platform.GL.nvidia.json.in > org.freedesktop.Platform.GL.nvidia-$NVIDIA_VERSION.json
+
+    echo "Packaging ${TARGET_ARCH} NVIDIA driver version ${VER} on ${ARCH} host..."
+
+    NVIDIA_VERSION=$(echo "${VER}" | tr '.' '-')
+    EXTRA_DATA=$(cat "${DATA_FILE}")
+    NVIDIA_SHA256=$(awk -F ':' '{print $2}' <<<"${EXTRA_DATA}")
+    NVIDIA_URL=$(awk -F '::' '{print $2}' <<<"${EXTRA_DATA}")
+
+    if test -z "${SUBJECT}"; then
+      SUBJECT="${VER}"
+      if test -d '.git'; then
+        SUBJECT="${SUBJECT} ($(git rev-parse --short HEAD))"
+      fi
+    fi
+
+    if test "${TARGET_ARCH}" = 'i386'; then
+      ARCH='x86_64'
+    else
+      ARCH=${TARGET_ARCH}
+    fi
+
+    sed -e "s/@@SDK_BRANCH@@/${SDK_BRANCH}/g" \
+      -e "s/@@SDK_RUNTIME_VERSION@@/${SDK_RUNTIME_VERSION}/g" \
+      -e "s/@@ARCH@@/${ARCH}/g" \
+      -e "s/@@NVIDIA_VERSION@@/${NVIDIA_VERSION}/g" \
+      -e "s=@@EXTRA_DATA@@=${EXTRA_DATA}=g" \
+      -e "s=@@NVIDIA_URL@@=${NVIDIA_URL}=g" \
+      -e "s/@@NVIDIA_ARCH@@/${TARGET_ARCH}/g" \
+      -e "s/@@NVIDIA_SHA256@@/${NVIDIA_SHA256}/g" \
+      "${EXT_PREFIX}.json.in" >"${EXT_PREFIX}-${NVIDIA_VERSION}.json"
 
     flatpak-builder -v --force-clean --ccache --sandbox --delete-build-dirs \
-                    --arch=${ARCH} --repo=${REPO} \
-                    --subject="${SUBJECT}" \
-                    ${FB_ARGS} ${EXPORT_ARGS} builddir org.freedesktop.Platform.GL.nvidia-$NVIDIA_VERSION.json
+      --arch="${ARCH}" \
+      --repo="${REPO}" \
+      --subject="${SUBJECT}" \
+      ${FB_ARGS} ${EXPORT_ARGS} builddir "${EXT_PREFIX}-${NVIDIA_VERSION}.json"
 
-    if test "${ARCH}" = "i386" ; then \
-        flatpak build-commit-from  ${EXPORT_ARGS} --src-ref=runtime/org.freedesktop.Platform.GL.nvidia-${NVIDIA_VERSION}/${ARCH}/${SDK_BRANCH} ${REPO} runtime/org.freedesktop.Platform.GL32.nvidia-${NVIDIA_VERSION}/x86_64/${SDK_BRANCH} ;
+    if test "${TARGET_ARCH}" = 'i386'; then
+      flatpak build-commit-from ${EXPORT_ARGS} \
+        --src-ref="runtime/${EXT_PREFIX}-${NVIDIA_VERSION}/${ARCH}/${SDK_BRANCH}" \
+        "${REPO}" \
+        "runtime/org.freedesktop.Platform.GL32.nvidia-${NVIDIA_VERSION}/${ARCH}/${SDK_BRANCH}"
     fi
-
-    rm org.freedesktop.Platform.GL.nvidia-$NVIDIA_VERSION.json
+    rm "${EXT_PREFIX}-${NVIDIA_VERSION}.json"
+  done
 done

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
     "skip-appstream-check": true,
-    "only-arches": ["x86_64","i386","aarch64"],
+    "only-arches": ["x86_64", "aarch64"],
     "publish-delay-hours": 0
 }

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -5,18 +5,17 @@
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
     "runtime-version": "@@SDK_RUNTIME_VERSION@@",
-    "sdk-extensions": [],
     "separate-locales": false,
-    "cleanup": ["/include"],
-    "build-options" : {
-        "append-ld-library-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib",
-        "append-pkg-config-path": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib/pkgconfig",
-        "cflags": "-O2 -g -I/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/include",
+    "cleanup": [ "/include" ],
+    "build-options": {
+        "append-ld-library-path": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib",
+        "append-pkg-config-path": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib/pkgconfig",
+        "cflags": "-O2 -g -I/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/include",
         "cxxflags": "-O2 -g",
-        "prefix": "/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@",
+        "ldflags": "-L/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib",
+        "prefix": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@",
         "env": {
-            "V": "1",
-            "LDFLAGS": "-L/usr/lib/GL/nvidia-@@NVIDIA_VERSION@@/lib"
+            "V": "1"
         }
     },
     "finish-args": [
@@ -24,6 +23,33 @@
         "--metadata=Extra Data=NoRuntime"
     ],
     "modules": [
+        {
+            "cleanup": [ "/include", "/share" ],
+            "name": "zlib",
+            "config-opts": [ "--static" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz",
+                    "sha256": "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32"
+                }
+            ]
+        },
+        {
+            "cleanup": [ "/include", "/share" ],
+            "name": "lzma",
+            "config-opts": [ "--disable-encoders", "--enable-decoders=lzma1,lzma2", "--disable-microlzma", "--disable-lzip-decoder",
+                             "--disable-xz", "--disable-xzdec", "--disable-lzmadec", "--disable-lzmainfo", "--disable-lzma-links",
+                             "--disable-scripts", "--disable-doc", "--disable-dependency-tracking", "--disable-shared"
+                           ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/tukaani-project/xz/releases/download/v5.6.3/xz-5.6.3.tar.xz",
+                    "sha256": "db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a"
+                }
+            ]
+        },
         {
             "name": "libzstd",
             "buildsystem": "simple",
@@ -43,7 +69,7 @@
             ]
         },
         {
-            "cleanup": ["/include", "/share"],
+            "cleanup": [ "/include", "/share" ],
             "name": "libarchive",
             "config-opts": [ "--disable-dependency-tracking", "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
                              "--without-bz2lib", "--without-iconv", "--without-lz4", "--without-lzo2", "--without-nettle",


### PR DESCRIPTION
This allows us to stop depending on the ancient 1.6 i386 SDK to package the i386 driver.

With these changes, the i386 driver is now packaged on a x86_64 host.

Unfortunately, we now also have to include zlib and liblzma, because the 24.08 SDK doesn't include static libraries (.a files) for them, and that will likely increase the overall build time.

---

I've tested the installation process on the following driver versions (x86_64 only):

- 367.57 (the oldest version we currently have)
- 470.256.02 (the latest driver supported by my GPU)
- 565.77 (the newest version we currently have)

I have not tested on aarch64, but I don't see why it would cause problems...

All changes are in a single commit on purpose, so we can easily revert it in case things go bad.