### PR TITLE
Fixup: Package the i386 driver on x86_64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,7 @@ for VER in $DRIVER_VERSIONS; do
     sed -e "s/@@SDK_BRANCH@@/${SDK_BRANCH}/g" \
       -e "s/@@SDK_RUNTIME_VERSION@@/${SDK_RUNTIME_VERSION}/g" \
       -e "s/@@ARCH@@/${ARCH}/g" \
+      -e "s/@@TARGET_ARCH@@/${TARGET_ARCH}/g" \
       -e "s/@@NVIDIA_VERSION@@/${NVIDIA_VERSION}/g" \
       -e "s=@@EXTRA_DATA@@=${EXTRA_DATA}=g" \
       -e "s=@@NVIDIA_URL@@=${NVIDIA_URL}=g" \

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -175,17 +175,15 @@ should_extract (struct archive_entry *entry)
       return 1;
     }
 
-#ifdef __i386__
   /* Nvidia no longer has 32bit drivers so we are getting
    * the 32bit compat libs from the 64bit drivers */
-  if (nvidia_major_version > 390)
+  if (strcmp (ARCH, "i386") == 0 && nvidia_major_version > 390)
     {
       if (!has_prefix (path, "32/"))
         return 0;
       is_compat32 = 1;
       path += 3;
     }
-#endif
 
   /* Skip these as we're using GLVND on majod > 367*/
   if (nvidia_major_version > 367 &&

--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -93,7 +93,7 @@
         },
         {
             "name": "nvidia",
-            "make-args": [ "NVIDIA_VERSION=@@NVIDIA_VERSION@@", "NVIDIA_URL=@@NVIDIA_URL@@", "ARCH=@@ARCH@@" ],
+            "make-args": [ "NVIDIA_VERSION=@@NVIDIA_VERSION@@", "NVIDIA_URL=@@NVIDIA_URL@@", "ARCH=@@TARGET_ARCH@@" ],
             "no-autogen": true,
             "sources": [
                 {


### PR DESCRIPTION
On PR #322, I forgot to update some places to make the driver extractor program (`nvidia-apply-extra.c`) properly extract the 32-bit driver files when installing the GL32 extension, as opposed to the x86_64 ones... This PR addresses that problem.