### PR TITLE
Use base extension with pre-built static libraries

### DIFF
--- a/org.freedesktop.Platform.GL.nvidia.json.in
+++ b/org.freedesktop.Platform.GL.nvidia.json.in
@@ -4,86 +4,21 @@
     "runtime": "org.freedesktop.Platform",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.nvidia-base"
+    ],
     "runtime-version": "@@SDK_RUNTIME_VERSION@@",
     "separate-locales": false,
-    "cleanup": [ "/include" ],
     "build-options": {
-        "append-ld-library-path": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib",
-        "append-pkg-config-path": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib/pkgconfig",
-        "cflags": "-O2 -g -I/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/include",
-        "cxxflags": "-O2 -g",
-        "ldflags": "-L/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@/lib",
-        "prefix": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@",
-        "env": {
-            "V": "1"
-        }
+        "prepend-ld-library-path": "/usr/lib/sdk/nvidia-base/lib",
+        "ldflags": "-L/usr/lib/sdk/nvidia-base/lib",
+        "prefix": "/usr/lib/@@ARCH@@-linux-gnu/GL/nvidia-@@NVIDIA_VERSION@@"
     },
     "finish-args": [
         "--extra-data=@@EXTRA_DATA@@",
         "--metadata=Extra Data=NoRuntime"
     ],
     "modules": [
-        {
-            "cleanup": [ "/include", "/share" ],
-            "name": "zlib",
-            "config-opts": [ "--static" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz",
-                    "sha256": "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32"
-                }
-            ]
-        },
-        {
-            "cleanup": [ "/include", "/share" ],
-            "name": "lzma",
-            "config-opts": [ "--disable-encoders", "--enable-decoders=lzma1,lzma2", "--disable-microlzma", "--disable-lzip-decoder",
-                             "--disable-xz", "--disable-xzdec", "--disable-lzmadec", "--disable-lzmainfo", "--disable-lzma-links",
-                             "--disable-scripts", "--disable-doc", "--disable-dependency-tracking", "--disable-shared"
-                           ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/tukaani-project/xz/releases/download/v5.6.3/xz-5.6.3.tar.xz",
-                    "sha256": "db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a"
-                }
-            ]
-        },
-        {
-            "name": "libzstd",
-            "buildsystem": "simple",
-            "subdir": "lib",
-            "build-options": {
-                "cppflags": "-DZSTD_MULTITHREAD"
-            },
-            "build-commands": [
-                "make -j ${FLATPAK_BUILDER_N_JOBS} PREFIX=${FLATPAK_DEST} install-static install-includes install-pc"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz",
-                    "sha256": "8c29e06cf42aacc1eafc4077ae2ec6c6fcb96a626157e0593d5e82a34fd403c1"
-                }
-            ]
-        },
-        {
-            "cleanup": [ "/include", "/share" ],
-            "name": "libarchive",
-            "config-opts": [ "--disable-dependency-tracking", "--disable-shared", "--enable-static", "--disable-xattr", "--disable-acl",
-                             "--without-bz2lib", "--without-iconv", "--without-lz4", "--without-lzo2", "--without-nettle",
-                             "--without-openssl", "--without-xml2", "--without-expat", "--disable-bsdcat", "--disable-bsdcpio",
-                             "--disable-bsdtar", "--disable-bsdunzip", "--without-libb2", "--without-cng", "--without-mbedtls"
-                           ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libarchive/libarchive/releases/download/v3.7.7/libarchive-3.7.7.tar.xz",
-                    "sha256": "879acd83c3399c7caaee73fe5f7418e06087ab2aaf40af3e99b9e29beb29faee"
-                }
-            ]
-        },
         {
             "name": "ldconfig",
             "buildsystem": "simple",


### PR DESCRIPTION
This base extension contains pre-built static libraries for zlib, liblzma, libzstd and libarchive, meaning we don't have to download and compile these libraries for every version we package.

The speed gain is massive: Without this extension, packaging 5 different driver versions on my personal computer (quad-core CPU @ 3.6 GHz) took a whopping 6 minutes.

With the base extension, the same packaging process took only 23 seconds, almost 16 times faster!

---

Marking as draft for now, though, because I intend to merge this when NVIDIA releases their next driver - just to avoid releasing multiple updates needlessly [and annoying users](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/issues/42).

Collaborators, feel free to review or question these changes in the meantime.