### PR TITLE
Add CUDA 570.86.10

### DIFF
--- a/data/nvidia-570.86.10-aarch64.data
+++ b/data/nvidia-570.86.10-aarch64.data
@@ -1,0 +1,1 @@
+:ce431100671452c5e2f53bd8c9974b2693bc11e989171557debbe8b22f68dca1:289370884::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-aarch64-570.86.10.run

--- a/data/nvidia-570.86.10-i386.data
+++ b/data/nvidia-570.86.10-i386.data
@@ -1,0 +1,1 @@
+:0d9d7059c046f0bc1112746e0e307d6136c7cb958a6a58db80c0b56d0e6c149f:375767278::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-570.86.10.run

--- a/data/nvidia-570.86.10-x86_64.data
+++ b/data/nvidia-570.86.10-x86_64.data
@@ -1,0 +1,1 @@
+:0d9d7059c046f0bc1112746e0e307d6136c7cb958a6a58db80c0b56d0e6c149f:375767278::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-570.86.10.run

--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -127,6 +127,10 @@ should_extract (struct archive_entry *entry)
   if (has_prefix (path, "./"))
     path += 2;
 
+  /* Ignore the '32' directory (32-bit only libraries) when extracting on non-GL32. */
+  if (strcmp (ARCH, "i386") != 0 && has_prefix (path, "32/"))
+    return 0;
+
   if (strcmp (path, "nvidia_icd.json") == 0 || strcmp (path, "nvidia_icd.json.template") == 0)
     {
       archive_entry_set_pathname (entry, "./vulkan/icd.d/nvidia_icd.json");

--- a/versions.sh
+++ b/versions.sh
@@ -14,7 +14,7 @@ TESLA_VERSIONS="550.127.08 550.90.12 550.54.15 535.216.03 535.216.01 535.183.06 
 # NVIDIA sometimes publishes separate drivers just for CUDA that aren't available anywhere else
 # You need to manually create an entry in `data/` for this version, since these drivers exist
 # only at https://developer.nvidia.com/cuda-toolkit-archive for a specific CUDA version
-CUDA_VERSIONS="560.35.05 555.42.06 545.23.08"
+CUDA_VERSIONS="570.86.10 560.35.05 555.42.06 545.23.08"
 
 # TODO: When do we drop these?
 # Probably never: https://ahayzen.com/direct/flathub_downloads_only_nvidia_runtimes.txt


### PR DESCRIPTION
As usual, these installers were manually extracted by me from the ~5 GB CUDA 12.8.0 installers, for x86_64 and aarch64. I then uploaded the extracted installers to GitHub's [releases page](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/tag/cuda).

R570 is a new major version not previously packaged here, but as far as I could tell, the only difference between this version and R565 is the introduction of a new DLL called `nvngx_dlssg.dll`, which should be already covered by the driver extractor [here](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/blob/ece22284e21d10b53c4f70b1d33ec83b7b75af72/nvidia-apply-extra.c#L219-L224).

---

This PR also includes an unrelated commit that fixes #330.