### PR TITLE
Install nvoptix.bin

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -182,6 +182,12 @@ should_extract (struct archive_entry *entry)
       archive_entry_set_pathname (entry, new_path);
       return 1;
     }
+  if (strcmp (path, "nvoptix.bin") == 0)
+    {
+      snprintf (new_path, sizeof new_path, "./share/nvidia/%s", path);
+      archive_entry_set_pathname (entry, new_path);
+      return 1;
+    }
 
 libs_only:
   /* Nvidia no longer has 32bit drivers so we are getting


### PR DESCRIPTION
From the release notes of version [535.43.02](https://www.nvidia.com/en-us/drivers/details/205039/):

> Added `nvoptix.bin` to the driver package. This data file is used by the OptiX ray tracing engine library, `libnvoptix.so.1`.

[The documentation](https://us.download.nvidia.com/XFree86/Linux-x86_64/535.43.02/README/installedcomponents.html#:~:text=OptiX%20also%20includes%20a%20data%20file%20/usr/share/nvidia/nvoptix.bin.) tells us to install this file to `share/nvidia`.

Fixes #184