### PR TITLE
Revert "Extract just library files when on GL32"

### DIFF
--- a/nvidia-apply-extra.c
+++ b/nvidia-apply-extra.c
@@ -131,10 +131,6 @@ should_extract (struct archive_entry *entry)
   if (strcmp (ARCH, "i386") != 0 && has_prefix (path, "32/"))
     return 0;
 
-  /* Extract just library files when on GL32. */
-  if (strcmp (ARCH, "i386") == 0)
-    goto libs_only;
-
   if (strcmp (path, "nvidia_icd.json") == 0 || strcmp (path, "nvidia_icd.json.template") == 0)
     {
       archive_entry_set_pathname (entry, "./vulkan/icd.d/nvidia_icd.json");
@@ -189,7 +185,6 @@ should_extract (struct archive_entry *entry)
       return 1;
     }
 
-libs_only:
   /* Nvidia no longer has 32bit drivers so we are getting
    * the 32bit compat libs from the 64bit drivers */
   if (strcmp (ARCH, "i386") == 0 && nvidia_major_version > 390)
@@ -544,7 +539,7 @@ main (int argc, char *argv[])
       checked_symlink ("../libnvidia-allocator.so." NVIDIA_VERSION, "gbm/nvidia-drm_gbm.so");
     }
 
-  if (strcmp (ARCH, "i386") != 0 && nvidia_major_version >= 319)
+  if (nvidia_major_version >= 319)
     {
       checked_symlink ("nvidia-application-profiles-" NVIDIA_VERSION "-key-documentation",
                        "share/nvidia/nvidia-application-profiles-key-documentation");
@@ -559,16 +554,13 @@ main (int argc, char *argv[])
                        "libnvidia-tls.so." NVIDIA_VERSION);
     }
 
-  if (strcmp (ARCH, "i386") != 0)
-    {
-      mkdir ("OpenCL", 0755);
-      mkdir ("OpenCL/vendors", 0755);
-      create_file_with_content ("OpenCL/vendors/nvidia.icd", "libnvidia-opencl.so");
+  mkdir ("OpenCL", 0755);
+  mkdir ("OpenCL/vendors", 0755);
+  create_file_with_content ("OpenCL/vendors/nvidia.icd", "libnvidia-opencl.so");
 
-      if (nvidia_major_version > 340)
-        replace_string_in_file ("vulkan/icd.d/nvidia_icd.json",
-                                "__NV_VK_ICD__", "libGLX_nvidia.so.0");
-    }
+  if (nvidia_major_version > 340)
+    replace_string_in_file ("vulkan/icd.d/nvidia_icd.json",
+                            "__NV_VK_ICD__", "libGLX_nvidia.so.0");
 
   return 0;
 }


### PR DESCRIPTION
By not installing the Vulkan and EGL ICDs in the GL32 extension, we ended up breaking 32-bit Vulkan support for most applications that need it, e.g. game launchers that run 32-bit Windows games via Wine + DXVK.

The breakage was not noticed by me when I introduced this change, because my tests were only done using Flatpak'd Steam, which unluckily for me, includes a workaround that prevents the breakage.

The workaround is simple and consists of adding the path of the Vulkan ICD to the [`XDG_CONFIG_DIRS`](https://vulkan.lunarg.com/doc/view/1.3.250.1/windows/LoaderDriverInterface.html#driver-discovery-on-linux) environment variable, thus allowing the Vulkan Loader (`libvulkan.so`) to find it.

Another breakage affected applications using the EGL API (e.g. Wine with its native Wayland driver), which can also be worked around by modifying the [`__EGL_VENDOR_LIBRARY_DIRS`](https://github.com/NVIDIA/libglvnd/blob/606f6627cf481ee6dcb32387edc010c502cdf38b/src/EGL/icd_enumeration.md#icd-discovery) environment variable to make the EGL ICD discoverable.

For those reasons, I'm reintroducing the ICDs (and a few other files) to the GL32 extension.

Perhaps in the future we can investigate a different approach, e.g. by somehow integrating these workarounds directly in the Freedesktop runtime instead, which would eliminate the need to patch each application individually.

This reverts commit d55b7cb0e5269b5bd4b0d86ac8df2f77966451ce.

Closes #342
Reopens #112