### PR TITLE
CI/CD: Enable aarch64 builds

### DIFF
--- a/.github/workflows/flathub.yml
+++ b/.github/workflows/flathub.yml
@@ -26,8 +26,8 @@ jobs:
 
   build:
     needs: setup-matrix
-    name: Build batch ${{ matrix.id }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.arch }}-build-batch-${{ matrix.id }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
         include: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}

--- a/setup-matrix.py
+++ b/setup-matrix.py
@@ -13,10 +13,26 @@ versions = DRIVER_VERSIONS.split(" ")
 batch_size = 30
 matrix = []
 
+# Generate batches of driver versions for x86_64 / i386
 for start_idx in range(0, len(versions), batch_size):
     batch_versions = versions[start_idx : start_idx + batch_size]
     matrix.append(
         {
+            "arch": "x86_64",
+            "id": start_idx // batch_size,
+            "versions": " ".join(batch_versions),
+        }
+    )
+
+# Filter out driver versions that don't have an aarch64 build.
+aarch64_versions = [v for v in versions if os.path.isfile(f'./data/nvidia-{v}-aarch64.data')]
+
+# Generate batches of driver versions for aarch64
+for start_idx in range(0, len(aarch64_versions), batch_size):
+    batch_versions = aarch64_versions[start_idx : start_idx + batch_size]
+    matrix.append(
+        {
+            "arch": "aarch64",
             "id": start_idx // batch_size,
             "versions": " ".join(batch_versions),
         }


### PR DESCRIPTION
Please note that merging this as-is will trigger a full build of x86_64 drivers as well.

I'm only saying this because I'm not sure if Flathub runners have quota constraints...

There's an example run with these changes on my fork: https://github.com/guihkx/org.freedesktop.Platform.GL.nvidia/actions/runs/14679852840/job/41201168258