### PR TITLE
Add CUDA 575.51.03

### DIFF
--- a/data/nvidia-575.51.03-aarch64.data
+++ b/data/nvidia-575.51.03-aarch64.data
@@ -1,0 +1,1 @@
+:08723386320da2bbcd3da3d6c7a39d59be28841b68c0bb6dd3eede6d15baf3ec:306980281::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-aarch64-575.51.03.run

--- a/data/nvidia-575.51.03-i386.data
+++ b/data/nvidia-575.51.03-i386.data
@@ -1,0 +1,1 @@
+:db563ec94e413e25a65bb92c36a06970c4b27659102d3ee806f1b06b8c19b6d9:386801957::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-575.51.03.run

--- a/data/nvidia-575.51.03-x86_64.data
+++ b/data/nvidia-575.51.03-x86_64.data
@@ -1,0 +1,1 @@
+:db563ec94e413e25a65bb92c36a06970c4b27659102d3ee806f1b06b8c19b6d9:386801957::https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/download/cuda/NVIDIA-Linux-x86_64-575.51.03.run

--- a/versions.sh
+++ b/versions.sh
@@ -14,7 +14,7 @@ TESLA_VERSIONS="570.133.20 570.124.06 570.86.15 550.127.08 550.90.12 550.54.15 5
 # NVIDIA sometimes publishes separate drivers just for CUDA that aren't available anywhere else
 # You need to manually create an entry in `data/` for this version, since these drivers exist
 # only at https://developer.nvidia.com/cuda-toolkit-archive for a specific CUDA version
-CUDA_VERSIONS="570.86.10 560.35.05 555.42.06 545.23.08"
+CUDA_VERSIONS="575.51.03 570.86.10 560.35.05 555.42.06 545.23.08"
 
 # TODO: When do we drop these?
 # Probably never: https://ahayzen.com/direct/flathub_downloads_only_nvidia_runtimes.txt


### PR DESCRIPTION
As usual, these installers were manually extracted by me from the 5 GB CUDA 12.9.0 installers, for x86_64 and aarch64. I then uploaded the extracted installers to [our releases page](https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/releases/tag/cuda).