### PR TITLE
Add custom-versioned `libnvidia-nvvm70`

### DIFF
--- a/nvidia-extractor/nvidia-extract.c
+++ b/nvidia-extractor/nvidia-extract.c
@@ -217,7 +217,8 @@ should_extract (struct archive_entry *entry)
       strstr (path, "egl-gbm") ||
       strstr (path, "egl-xcb") ||
       strstr (path, "egl-xlib") ||
-      strstr (path, "libnvidia-api"))
+      strstr (path, "libnvidia-api") ||
+      strstr (path, "libnvidia-nvvm70"))
     {
       snprintf (new_path, sizeof new_path, "./lib/%s", path);
       archive_entry_set_pathname (entry, new_path);


### PR DESCRIPTION
This is one of those libraries that aren't versioned after the driver version (like most libraries are), so we have to manually mark it for extraction.

This library was introduced in [beta driver 575.51.02](https://www.nvidia.com/en-us/drivers/details/243334/).