### PR TITLE
CI: Free up more disk space

### DIFF
--- a/.github/workflows/flathub.yml
+++ b/.github/workflows/flathub.yml
@@ -40,15 +40,33 @@ jobs:
 
       - name: Free up disk space
         run: |
+          sudo swapoff -a || true
           sudo rm -rf /opt/ghc /usr/local/.ghcup || true
           sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /opt/hostedtoolcache/PyPy
+          sudo rm -rf /usr/share/gradle-*
+          sudo rm -rf /usr/local/julia* /usr/share/java /usr/share/kotlinc
+          sudo rm -rf /opt/hostedtoolcache/go /opt/az /opt/microsoft /opt/pipx
+          sudo rm -rf /usr/share/miniconda /home/runner/.rustup /home/packer/.rustup /home/runneradmin/.rustup
+          sudo rm -rf /etc/skel/.rustup /opt/hostedtoolcache/node /opt/google-cloud-sdk
+          sudo rm -rf /usr/share/az_* /opt/google /usr/lib/firefox /usr/local/aws-*
+          sudo rm -rf /usr/libexec/gcc /opt/actionarchivecache /opt/hostedtoolcache/Ruby
+          sudo rm -rf /var/lib/mysql /usr/local/n
           sudo rm -rf /swapfile || true
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet /usr/share/swift
           sudo rm -rf /usr/local/share/boost /usr/local/share/powershell
           sudo rm -rf /usr/lib/google-cloud-sdk /usr/lib/jvm
-          sudo apt-get clean
+          sudo rm -rf /usr/local/graalvm /usr/local/share/chromium
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo rm -rf /usr/lib/dotnet /usr/lib/php /usr/share/mysql
+          sudo rm -rf /usr/lib/llvm-*
+          sudo rm -rf /usr/lib/mono
+          sudo apt-get clean || true
           sudo rm -rf /var/lib/apt/lists/*
+          timeout 5 df -hHl || true
+          timeout 5 free -h --giga || true
+          timeout 120 sudo du -xh --max-depth=3 / 2>/dev/null | sort -rh | head -40 || true
 
       - name: Download justfile
         run: |


### PR DESCRIPTION
This is an attempt to fix a recent failure in CI (lack of free disk space):

```
FB: Running: flatpak build-finish /work/builddir
Finishing app
Please review the exported files and the metadata
Committing stage finish to cache
Bundling sources
Committing stage bundle-sources to cache
FB: Running: flatpak build-export --arch=x86_64 '--subject=Add 580.82.07 (20bd003)' '--exclude=/lib/debug/*' --include=/lib/debug/app /work/repo builddir 1.4
Exporting org.freedesktop.Platform.GL.nvidia-550-120 to repo
error: Writing content object: min-free-space-percent '3%' would be exceeded, at least 4.1 kB requested
Export failed: Child process exited with code 1
make: *** [Makefile:8: all] Error 1
```

Build job: https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/actions/runs/17411498111/job/49429548142

These removed directories were copied from Flathub's build orchestrator (vorarbeiter): https://github.com/flathub-infra/vorarbeiter/blob/eed024e927c54fef7f5e5a5e5a6f90686f54b9b2/.github/workflows/build.yml#L308-L336