### PR TITLE
CI: Reduce build batches from 30 to 15

### DIFF
--- a/setup-matrix.py
+++ b/setup-matrix.py
@@ -10,7 +10,7 @@ if DRIVER_VERSIONS is None:
     sys.exit(1)
 
 versions = DRIVER_VERSIONS.split(" ")
-batch_size = 30
+batch_size = 15
 matrix = []
 
 # Generate batches of driver versions for x86_64 / i386


### PR DESCRIPTION
We keep running out of disk space while exporting the drivers: https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/actions/runs/17412754189/job/49435186818#step:6:5294

I first tried to work around this in #378, but that wasn't enough, so let's try to reduce the build batches from 30 to 15 and see how it goes.

My guess is that this is happening now because the forked version of `flatpak-builder` we use to build the drivers [was recently modified](https://github.com/flathub-infra/flatpak-builder/commit/9d54e13a6c042558ff2265f279d60e358f86246b) to always export a `.Sources` package(?) for x86_64 builds, which seems to require about twice as much disk space as before...
