### PR TITLE
Add 580.105.08 for aarch64

### DIFF
--- a/data/nvidia-580.105.08-aarch64.data
+++ b/data/nvidia-580.105.08-aarch64.data
@@ -1,0 +1,1 @@
+:bf95a1863878c25ed30082eabb998d1af739de911202b95c936356be6a612088:313374695::https://us.download.nvidia.com/tesla/580.105.08/NVIDIA-Linux-aarch64-580.105.08.run


### PR DESCRIPTION
A couple of days ago, when the GeForce driver 580.105.08 was released by NVIDIA (commit 16d5672f), they apparently forgot to release that version for aarch64.

See these user reports:

- https://forums.developer.nvidia.com/t/580-release-feedback-discussion/341205/724
- https://forums.developer.nvidia.com/t/580-release-feedback-discussion/341205/735
- https://forums.developer.nvidia.com/t/580-release-feedback-discussion/341205/744

The GeForce driver is still unavailable at the time of writing, but today NVIDIA released the same version for Tesla GPUs, which includes the missing aarch64 driver added in this commit.
