### PR TITLE
Install config file for `libnvidia-egl-wayland2.so.1`

### DIFF
--- a/nvidia-extractor/nvidia-extract.c
+++ b/nvidia-extractor/nvidia-extract.c
@@ -174,6 +174,11 @@ should_extract (struct archive_entry *entry)
       archive_entry_set_pathname (entry, "./egl/egl_external_platform.d/20_nvidia_xlib.json");
       return 1;
     }
+  if (strcmp (path, "99_nvidia_wayland2.json") == 0)
+    {
+      archive_entry_set_pathname (entry, "./egl/egl_external_platform.d/99_nvidia_wayland2.json");
+      return 1;
+    }
   if (strcmp (path, "nvidia_icd_vksc.json") == 0)
     {
       archive_entry_set_pathname (entry, "./vulkansc/icd.d/nvidia_icd_vksc.json");


### PR DESCRIPTION
This is a config file for a new EGL external platform library, introduced with beta driver version 590.44.01:

https://www.nvidia.com/en-us/drivers/details/258750/

P.S.: Like PR #394, this remains untested: I don't have an NVIDIA card that's supported by this driver version. We'll have to wait on user feedback to know whether this works or not.