### PR TITLE
CI: Stop generating static deltas

### DIFF
--- a/.github/workflows/flathub.yml
+++ b/.github/workflows/flathub.yml
@@ -104,14 +104,6 @@ jobs:
               export DRIVER_VERSIONS="${{ matrix.versions }}"
               make
             '
-      - name: Generate deltas
-        run: |
-          docker run --rm --privileged \
-            --entrypoint="" \
-            -v "${GITHUB_WORKSPACE}/work:/work" \
-            -w /work \
-            ghcr.io/flathub-infra/flatpak-builder-lint:latest \
-            just generate-deltas
 
       - name: Upload and publish build
         run: |


### PR DESCRIPTION
The option has been removed from Vorarbeiter:

https://github.com/flathub-infra/vorarbeiter/commit/8675f1836eef1873531712af662f6cbe6baacb51
