### PR TITLE
Fix install path of JSON loader for `egl-wayland2`

### DIFF
--- a/nvidia-extractor/nvidia-extract.c
+++ b/nvidia-extractor/nvidia-extract.c
@@ -149,14 +149,14 @@ should_extract (struct archive_entry *entry)
       archive_entry_set_pathname (entry, "./vulkan/implicit_layer.d/nvidia_layers.json");
       return 1;
     }
-  if (strcmp (path, "09_nvidia_wayland2.json") == 0)
-    {
-      archive_entry_set_pathname (entry, "./glvnd/egl_vendor.d/09_nvidia_wayland2.json");
-      return 1;
-    }
   if (strcmp (path, "10_nvidia.json") == 0)
     {
       archive_entry_set_pathname (entry, "./glvnd/egl_vendor.d/10_nvidia.json");
+      return 1;
+    }
+  if (strcmp (path, "09_nvidia_wayland2.json") == 0)
+    {
+      archive_entry_set_pathname (entry, "./egl/egl_external_platform.d/09_nvidia_wayland2.json");
       return 1;
     }
   if (strcmp (path, "10_nvidia_wayland.json") == 0)


### PR DESCRIPTION
The `09_nvidia_wayland2.json` file is a loader for an external platform library, so it should be installed to `egl/egl_external_platform.d`, and not to `glvnd/egl_vendor.d`.

Closes #440